### PR TITLE
add: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM google/golang
+MAINTAINER Sevki <s@sevki.org>
+
+ADD . /gopath/src/willnorris.com/go/imageproxy
+RUN go get willnorris.com/go/imageproxy/cmd/imageproxy
+
+CMD []
+ENTRYPOINT ["/gopath/bin/imageproxy"]
+
+EXPOSE 8080


### PR DESCRIPTION
hey @willnorris, 

this image should be built by
```
git clone git@github.com:willnorris/imageproxy.git
cd  imageproxt
docker build -t imageproxy .
```
and run
`docker run -p 8080:8080 imageproxy -addr 0.0.0.0:8080`

or by pulling the image from docker hub @ [`sevki/imageproxy`](https://registry.hub.docker.com/u/sevki/imageproxy/build_id/62252/code/bcrlplvomm2szsbsbmvwmab/)

`docker run -p 8080:8080 sevki/imageproxy -addr 0.0.0.0:8080`

there should also be a automated build for this, I can send  you a dockerhub endpoint or you can build an automated build your self. 

I tried looking for something that builds and tests docker images but I couldn't find one. 

