### PR TITLE
Allowing disabling of cache

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -62,7 +62,7 @@ func main() {
 			CacheSizeMax: *cacheSize * 1024 * 1024,
 		})
 		c = diskcache.NewWithDiskv(d)
-	} else {
+	} else if *cacheSize != 0 {
 		c = httpcache.NewMemoryCache()
 	}
 


### PR DESCRIPTION
This PR makes it possible to disable caching entirely. This is useful if the imageproxy sits behind a CDN.

You can now run the following to set the cache to `NopCache`:

```
imageproxy -cacheSize 0
```

I don't see any tests for `cmd`, so I didn't add one. Let me know what you think.
