### PR TITLE
Scaling images beyond original size

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ effective method to mask the true source of the images being proxied; it is
 trivial to discover the base URL being used.  Even when a base URL is
 specified, you can always provide the absolute URL of the image to be proxied.
 
+### Scaling beyond original size ###
+
+By default, the imageproxy won't scale images beyond their original size. However, you can use the `scaleUp` command-line flag to allow this to happen:
+
+    imageproxy -scaleUp true
 
 ## Deploying ##
 

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -45,6 +45,7 @@ var baseURL = flag.String("baseURL", "", "default base URL for relative remote U
 var cacheDir = flag.String("cacheDir", "", "directory to use for file cache")
 var cacheSize = flag.Uint64("cacheSize", 100, "maximum size of file cache (in MB)")
 var signatureKey = flag.String("signatureKey", "", "HMAC key used in calculating request signatures")
+var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their original dimensions")
 var version = flag.Bool("version", false, "print version information")
 
 func main() {
@@ -89,6 +90,8 @@ func main() {
 			log.Fatalf("error parsing baseURL: %v", err)
 		}
 	}
+
+	p.ScaleUp = *scaleUp
 
 	server := &http.Server{
 		Addr:    *addr,

--- a/data.go
+++ b/data.go
@@ -65,6 +65,9 @@ type Options struct {
 
 	// HMAC Signature for signed requests.
 	Signature string
+
+	// Allow images to scale beyond their original dimensions.
+	ScaleUp bool
 }
 
 var emptyOptions = Options{}

--- a/data_test.go
+++ b/data_test.go
@@ -29,11 +29,11 @@ func TestOptions_String(t *testing.T) {
 			"0x0",
 		},
 		{
-			Options{1, 2, true, 90, true, true, 80, ""},
+			Options{1, 2, true, 90, true, true, 80, "", false},
 			"1x2,fit,r90,fv,fh,q80",
 		},
 		{
-			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee"},
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false},
 			"0.15x1.3,r45,q95,sc0ffee",
 		},
 	}
@@ -82,8 +82,8 @@ func TestParseOptions(t *testing.T) {
 		{"FOO,1,BAR,r90,BAZ", Options{Width: 1, Height: 1, Rotate: 90}},
 
 		// all flags, in different orders
-		{"q70,1x2,fit,r90,fv,fh,sc0ffee", Options{1, 2, true, 90, true, true, 70, "c0ffee"}},
-		{"r90,fh,sc0ffee,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee"}},
+		{"q70,1x2,fit,r90,fv,fh,sc0ffee", Options{1, 2, true, 90, true, true, 70, "c0ffee", false}},
+		{"r90,fh,sc0ffee,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false}},
 	}
 
 	for _, tt := range tests {

--- a/transform.go
+++ b/transform.go
@@ -102,11 +102,13 @@ func transformImage(m image.Image, opt Options) image.Image {
 	}
 
 	// never resize larger than the original image
-	if w > imgW {
-		w = imgW
-	}
-	if h > imgH {
-		h = imgH
+	if !opt.ScaleUp {
+		if w > imgW {
+			w = imgW
+		}
+		if h > imgH {
+			h = imgH
+		}
 	}
 
 	// resize

--- a/transform_test.go
+++ b/transform_test.go
@@ -127,6 +127,11 @@ func TestTransformImage(t *testing.T) {
 			Options{Width: 100, Height: 100},
 			ref,
 		},
+		{ // can resize larger than original image
+			ref,
+			Options{Width: 4, Height: 4, ScaleUp: true},
+			newImage(4, 4, red, red, green, green, red, red, green, green, blue, blue, yellow, yellow, blue, blue, yellow, yellow),
+		},
 		{ // invalid values
 			ref,
 			Options{Width: -1, Height: -1},


### PR DESCRIPTION
This PR adds the functionality discussed in #35:

Specific settings in the `Proxy` object can now be set on the `Options` object before running the `Transform` function: https://github.com/runemadsen/imageproxy/blob/master/imageproxy.go#L269-L272

I tested it all on localhost, and it's working.

Let me know what you think.

