### PR TITLE
Forwarding cache-control header

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -124,6 +124,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cached := resp.Header.Get(httpcache.XFromCache)
 	glog.Infof("request: %v (served from cache: %v)", *req, cached == "1")
 
+	copyHeader(w, resp, "Cache-Control")
 	copyHeader(w, resp, "Last-Modified")
 	copyHeader(w, resp, "Expires")
 	copyHeader(w, resp, "Etag")


### PR DESCRIPTION
CDN's like Cloudfront likes the `Cache-Control` header over `Expires`, and currently the imageproxy does not forward this header, resulting in the CDN never caching the image. This PR adds the `Cache-Control` header to the imageproxy response.