### PR TITLE
Skip scaling if image is smaller than requested

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -79,7 +79,7 @@ func Transform(img []byte, opt Options) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func resizeParams(m image.Image, opt *Options) (w, h int) {
+func resizeParams(m image.Image, opt *Options) (w, h int, resize bool) {
 	// convert percentage width and height values to absolute values
 	imgW := m.Bounds().Max.X - m.Bounds().Min.X
 	imgH := m.Bounds().Max.Y - m.Bounds().Min.Y
@@ -107,14 +107,18 @@ func resizeParams(m image.Image, opt *Options) (w, h int) {
 			h = imgH
 		}
 	}
-	return
+	// if requested width and height match the original, skip resizing
+	if (w == imgW || w == 0) && (h == imgH || h == 0) {
+		return 0, 0, false
+	}
+	return w, h, true
 }
 
 // transformImage modifies the image m based on the transformations specified
 // in opt.
 func transformImage(m image.Image, opt Options) image.Image {
 	// resize if needed
-	if w, h := resizeParams(m, &opt); w != 0 || h != 0 {
+	if w, h, resize := resizeParams(m, &opt); resize {
 		if opt.Fit {
 			m = imaging.Fit(m, w, h, resampleFilter)
 		} else {

--- a/transform.go
+++ b/transform.go
@@ -79,13 +79,10 @@ func Transform(img []byte, opt Options) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// transformImage modifies the image m based on the transformations specified
-// in opt.
-func transformImage(m image.Image, opt Options) image.Image {
+func resizeParams(m image.Image, opt *Options) (w, h int) {
 	// convert percentage width and height values to absolute values
 	imgW := m.Bounds().Max.X - m.Bounds().Min.X
 	imgH := m.Bounds().Max.Y - m.Bounds().Min.Y
-	var w, h int
 	if 0 < opt.Width && opt.Width < 1 {
 		w = int(float64(imgW) * opt.Width)
 	} else if opt.Width < 0 {
@@ -110,9 +107,14 @@ func transformImage(m image.Image, opt Options) image.Image {
 			h = imgH
 		}
 	}
+	return
+}
 
-	// resize
-	if w != 0 || h != 0 {
+// transformImage modifies the image m based on the transformations specified
+// in opt.
+func transformImage(m image.Image, opt Options) image.Image {
+	// resize if needed
+	if w, h := resizeParams(m, &opt); w != 0 || h != 0 {
 		if opt.Fit {
 			m = imaging.Fit(m, w, h, resampleFilter)
 		} else {

--- a/transform_test.go
+++ b/transform_test.go
@@ -40,20 +40,22 @@ func newImage(w, h int, pixels ...color.NRGBA) image.Image {
 func TestResizeParams(t *testing.T) {
 	src := image.NewNRGBA(image.Rect(0, 0, 64, 128))
 	tests := []struct {
-		opt Options
-		w,h int
+		opt  Options
+		w, h int
+		resize bool
 	}{
-		{Options{Width:0.5}, 32, 0},
-		{Options{Height:0.5}, 0, 64},
-		{Options{Width:0.5, Height:0.5}, 32, 64},
-		{Options{Width:100, Height: 200}, 64, 128},
-		{Options{Width:64}, 64, 0},
-		{Options{Height:128}, 0, 128},
+		{Options{Width: 0.5}, 32, 0, true},
+		{Options{Height: 0.5}, 0, 64, true},
+		{Options{Width: 0.5, Height: 0.5}, 32, 64, true},
+		{Options{Width: 100, Height: 200}, 0, 0, false},
+		{Options{Width: 100, Height: 200, ScaleUp: true}, 100, 200, true},
+		{Options{Width: 64}, 0, 0, false},
+		{Options{Height: 128}, 0, 0, false},
 	}
-	for ti,tt := range tests {
-		w,h := resizeParams(src, &tt.opt)
-		if w != tt.w || h!= tt.h {
-			t.Errorf("test %d problem, want: %d,%d got: %d,%d", ti, tt.w, tt.h, w, h)
+	for ti, tt := range tests {
+		w, h, resize := resizeParams(src, &tt.opt)
+		if w != tt.w || h != tt.h || resize != tt.resize {
+			t.Errorf("test %d problem, want: %d,%d,%t got: %d,%d,%t", ti, tt.w, tt.h, tt.resize, w, h, resize)
 		}
 	}
 }

--- a/transform_test.go
+++ b/transform_test.go
@@ -37,6 +37,27 @@ func newImage(w, h int, pixels ...color.NRGBA) image.Image {
 	return m
 }
 
+func TestResizeParams(t *testing.T) {
+	src := image.NewNRGBA(image.Rect(0, 0, 64, 128))
+	tests := []struct {
+		opt Options
+		w,h int
+	}{
+		{Options{Width:0.5}, 32, 0},
+		{Options{Height:0.5}, 0, 64},
+		{Options{Width:0.5, Height:0.5}, 32, 64},
+		{Options{Width:100, Height: 200}, 64, 128},
+		{Options{Width:64}, 64, 0},
+		{Options{Height:128}, 0, 128},
+	}
+	for ti,tt := range tests {
+		w,h := resizeParams(src, &tt.opt)
+		if w != tt.w || h!= tt.h {
+			t.Errorf("test %d problem, want: %d,%d got: %d,%d", ti, tt.w, tt.h, w, h)
+		}
+	}
+}
+
 func TestTransform(t *testing.T) {
 	src := newImage(2, 2, red, green, blue, yellow)
 


### PR DESCRIPTION
If original image has width/height smaller than requested and no upscaling then skip resizing.