### PR TITLE
changed gopahts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM google/golang
 MAINTAINER Sevki <s@sevki.org>
 
-ADD . /gopath/src/willnorris.com/go/imageproxy
+ADD . /go/src/willnorris.com/go/imageproxy
 RUN go get willnorris.com/go/imageproxy/cmd/imageproxy
 
 CMD []
-ENTRYPOINT ["/gopath/bin/imageproxy"]
+ENTRYPOINT ["/go/bin/imageproxy"]
 
 EXPOSE 8080


### PR DESCRIPTION
google's golang base image changed their gopath from `/gopath` to `/go`
hence the problems 