### PR TITLE
Added "iopts" mode allowing passing options via a `?iopts=[options]` query parameter

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -50,6 +50,7 @@ var cacheSize = flag.Uint64("cacheSize", 0, "Deprecated: this flag does nothing"
 var signatureKey = flag.String("signatureKey", "", "HMAC key used in calculating request signatures")
 var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their original dimensions")
 var version = flag.Bool("version", false, "print version information")
+var ioptsMode = flag.Bool("ioptsMode", false, "specify transformation options using the query string ?iopts=[options] instead of specifying options in the path")
 
 func main() {
 	flag.Parse()
@@ -92,6 +93,7 @@ func main() {
 	}
 
 	p.ScaleUp = *scaleUp
+	p.IoptsMode = *ioptsMode
 
 	server := &http.Server{
 		Addr:    *addr,

--- a/data_test.go
+++ b/data_test.go
@@ -152,7 +152,7 @@ func TestNewRequest(t *testing.T) {
 			continue
 		}
 
-		r, err := NewRequest(req, nil)
+		r, err := NewRequest(req, nil, false)
 		if tt.ExpectError {
 			if err == nil {
 				t.Errorf("NewRequest(%v) did not return expected error", req)

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -62,6 +62,9 @@ type Proxy struct {
 
 	// Allow images to scale beyond their original dimensions.
 	ScaleUp bool
+
+	// Use ?iopts=[options] instead of the first element in the path
+	IoptsMode bool
 }
 
 // NewProxy constructs a new proxy.  The provided http RoundTripper will be
@@ -102,7 +105,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	req, err := NewRequest(r, p.DefaultBaseURL)
+	req, err := NewRequest(r, p.DefaultBaseURL, p.IoptsMode)
 	if err != nil {
 		msg := fmt.Sprintf("invalid request URL: %v", err)
 		glog.Error(msg)


### PR DESCRIPTION
- Setting the -ioptsMode=true flag will allow specifying URLs with the query string `?iopts=[your options]`

E.g.:

```
imageproxy -ioptsMode true
wget http://wwww.example.com/http://www.example.com/image.jpg?iopts=r90,480x
```
