### PR TITLE
adding azure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,13 @@ enabled using the `-cache` flag.  It supports the following values:
  - s3 URL (e.g. `s3://s3-us-west-2.amazonaws.com/my-bucket`) - will cache
    images on Amazon S3.  This requires either an IAM role and instance profile
    with access to your your bucket or `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`
-   environmental parameters set.
- - GCS URL (e.g. `gcs://bucket-name/optional-path-prefix`) - will cache
-   images on Google Cloud Storage.  This requires `GCP_PRIVATE_KEY` environmental
-   parameters set.
+   environmental variables be set.
+ - gcs URL (e.g. `gcs://bucket-name/optional-path-prefix`) - will cache images
+   on Google Cloud Storage.  This requires `GCP_PRIVATE_KEY` environmental
+   variable be set.
+ - azure URL (e.g. `azure://container-name/`) - will cache images on
+   Azure Storage.  This requires `AZURESTORAGE_ACCOUNT_NAME` and
+   `AZURESTORAGE_ACCESS_KEY` environmental variables set.
 
 For example, to cache files on disk in the `/tmp/imageproxy` directory:
 

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/PaulARoy/azurestoragecache"
 	"github.com/diegomarangoni/gcscache"
 	"github.com/gregjones/httpcache"
 	"github.com/gregjones/httpcache/diskcache"
@@ -129,6 +130,8 @@ func parseCache() (imageproxy.Cache, error) {
 		return s3cache.New(u.String()), nil
 	case "gcs":
 		return gcscache.New(u.String()), nil
+	case "azure":
+		return azurestoragecache.New("", "", u.Host)
 	case "file":
 		fallthrough
 	default:


### PR DESCRIPTION
I was using this amazing proxy on prod but without cache because my Azure App Service could not handle storage well enough.
But it was clearly not optimal. I thought it would be cool to add Azure Storage Support.

For that I needed an implementation of Http Cache with Azure Storage so I built one (http://github.com/PaulARoy/azurestoragecache)

This pull request only adds support for azure cache according to my package.

Usage: « -cache azure »
Three values can be passed on to the cache:
- Azure Account Name (empty = get env variable « AZURESTORAGE_ACCOUNT_NAME »)
- Azure Account Key (empty = get env variable « AZURESTORAGE_ACCESS_KEY »)
- Container Name (empty = "cache")

Feel free to modify anything. It currently runs in production for my website.