### PR TITLE
added user-agent header support via ENV var IMAGEPROXY_USER_AGENT

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -276,6 +277,11 @@ type TransformingTransport struct {
 
 // RoundTrip implements the http.RoundTripper interface.
 func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	userAgent := os.Getenv("IMAGEPROXY_USER_AGENT")
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+
 	if req.URL.Fragment == "" {
 		// normal requests pass through
 		glog.Infof("fetching remote URL: %v", req.URL)


### PR DESCRIPTION
I need this because the default User-Agent "Go-http-client/1.1" some sites block the downloading of images because they think we are scrapping.  With this patch you can set an environment variable 

`IMAGEPROXY_USER_AGENT="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"`

and it will use it as the User-Agent on all requests tricking the sites.