### PR TITLE
Add a -blacklist option to imageproxy to prevent access to certain hosts e.g. internal services

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,20 @@ Reload the [codercat URL][], and you should now get an error message.  You can
 specify multiple hosts as a comma separated list, or prefix a host value with
 `*.` to allow all sub-domains as well.
 
+### Host blacklist ###
+
+You can also blacklist certain hosts from the proxy by using the `blacklist`
+flag. This is useful in situations where the proxy is running on an internal
+network, for example under a docker swarm / weave setup, and you want to prevent
+it from having access to internal services. It can be prefixed with `*.` to
+blacklist all subdomains also. For a default docker swarm / weave setup you
+can prevent access to internal services by running:
+
+    imageproxy -blacklist *.weave.local
+
+You should now get an error message if you try to ask the proxy for a image
+located on some internal weave.local url.
+
 ### Signed Requests ###
 
 Instead of a host whitelist, you can require that requests be signed.  This is

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -42,6 +42,7 @@ var (
 
 var addr = flag.String("addr", "localhost:8080", "TCP address to listen on")
 var whitelist = flag.String("whitelist", "", "comma separated list of allowed remote hosts")
+var blacklist = flag.String("blacklist", "", "comma separated list of blacklisted remote hosts")
 var referrers = flag.String("referrers", "", "comma separated list of allowed referring hosts")
 var baseURL = flag.String("baseURL", "", "default base URL for relative remote URLs")
 var cache = flag.String("cache", "", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")
@@ -68,6 +69,9 @@ func main() {
 	p := imageproxy.NewProxy(nil, c)
 	if *whitelist != "" {
 		p.Whitelist = strings.Split(*whitelist, ",")
+	}
+	if *blacklist != "" {
+		p.Blacklist = strings.Split(*blacklist, ",")
 	}
 	if *referrers != "" {
 		p.Referrers = strings.Split(*referrers, ",")

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -44,6 +44,10 @@ type Proxy struct {
 	// proxied from.  An empty list means all hosts are allowed.
 	Whitelist []string
 
+	// Blacklist specifies a list of domains that should not be possible
+	// to proxy from. An empty list means all domains are allowed.
+	Blacklist []string
+
 	// Referrers, when given, requires that requests to the image
 	// proxy come from a referring host. An empty list means all
 	// hosts are allowed.

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -174,6 +174,10 @@ func (p *Proxy) allowed(r *Request) error {
 		return fmt.Errorf("request does not contain an allowed referrer: %v", r)
 	}
 
+	if(blacklistedHost(p.Blacklist, r.URL)) {
+		return fmt.Errorf("request does not contain an allowed host %v", r)
+	}
+
 	if len(p.Whitelist) == 0 && len(p.SignatureKey) == 0 {
 		return nil // no whitelist or signature key, all requests accepted
 	}
@@ -191,6 +195,20 @@ func (p *Proxy) allowed(r *Request) error {
 
 // validHost returns whether the host in u matches one of hosts.
 func validHost(hosts []string, u *url.URL) bool {
+	for _, host := range hosts {
+		if u.Host == host {
+			return true
+		}
+		if strings.HasPrefix(host, "*.") && strings.HasSuffix(u.Host, host[2:]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// blacklistedHost returns true if the host is in our blacklist
+func blacklistedHost(hosts []string, u *url.URL) bool {
 	for _, host := range hosts {
 		if u.Host == host {
 			return true


### PR DESCRIPTION
For our setup we needed to be able to prevent imageproxy access to certain internal services running under our docker swarm cluster. I added a -blacklist option to make it possible to prevent the proxy from accessing services available on *.weave.local.