### PR TITLE
Rectangle crop feature

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -31,12 +31,20 @@ func TestOptions_String(t *testing.T) {
 			"0x0",
 		},
 		{
-			Options{1, 2, true, 90, true, true, 80, "", false, ""},
+			Options{1, 2, true, 90, true, true, 80, "", false, "", 0, 0, 0, 0},
 			"1x2,fit,r90,fv,fh,q80",
 		},
 		{
-			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png"},
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 0, 0, 0, 0},
 			"0.15x1.3,r45,q95,sc0ffee,png",
+		},
+		{
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "", 100, 200, 0, 0},
+			"0.15x1.3,r45,q95,sc0ffee,cw100,ch200",
+		},
+		{
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 100, 200, 300, 400},
+			"0.15x1.3,r45,q95,sc0ffee,png,cw100,ch200,cx300,cy400",
 		},
 	}
 
@@ -85,9 +93,20 @@ func TestParseOptions(t *testing.T) {
 		// mix of valid and invalid flags
 		{"FOO,1,BAR,r90,BAZ", Options{Width: 1, Height: 1, Rotate: 90}},
 
-		// all flags, in different orders
-		{"q70,1x2,fit,r90,fv,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png"}},
-		{"r90,fh,sc0ffee,png,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png"}},
+		// flags, in different orders
+		{"q70,1x2,fit,r90,fv,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 0, 0, 0, 0}},
+		{"r90,fh,sc0ffee,png,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 0, 0, 0, 0}},
+
+		// all flags, in different orders with crop
+		{"q70,cw100,cx300,1x2,fit,ch200,r90,fv,cy400,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400}},
+		{"cy400,r90,cx300,fh,sc0ffee,png,cw100,q90,ch200,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400}},
+
+		// all flags, in different orders with crop & different resizes
+		{"q70,cw100,cx300,x2,fit,ch200,r90,fv,cy400,fh,sc0ffee,png", Options{0, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400}},
+		{"cy400,r90,cx300,fh,sc0ffee,png,cw100,q90,ch200,1x,fv,fit", Options{1, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400}},
+		{"cy400,r90,cx300,fh,sc0ffee,png,cw100,q90,ch200,cx,fv,fit", Options{0, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400}},
+		{"cy400,r90,cx300,fh,sc0ffee,png,cw100,q90,ch200,cx,fv,fit,123x321", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400}},
+		{"123x321,cy400,r90,cx300,fh,sc0ffee,png,cw100,q90,ch200,cx,fv,fit", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
I have managed to implement a rectangle crop feature. It adds four new parameters: `cw` - rectangle width, `ch` - rectangle height, `cx` - X coordinate of top left rectangle point and `cy` - Y coordinate of top left rectangle point. The crop is applied before any other transformations and can affect scaling if the rectangle is smaller than the requested image dimensions and `scaleUp` is disabled (resulting image will be of the same size as crop rectangle).

The feature was requested in #19 and mentioned in #55, so I hope you'll find my contribution useful :)