### PR TITLE
Add wercker to build the slim alpine based container with 10MB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .goxc.local.json
 *.test
+.wercker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/golang
+FROM google/golang-alpine
 MAINTAINER Sevki <s@sevki.org>
 
 ADD . /go/src/willnorris.com/go/imageproxy

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,53 @@
+build:
+    box: golang
+    steps:
+    - setup-go-workspace:
+        package-dir: willnorris.com/go/imageproxy
+
+    - golint:
+      exclude: vendor
+
+    - script:
+        name: go fmt
+        code: |
+          output=$(go fmt willnorris.com/go/imageproxy/...)
+          if [[ $(echo -n $output | wc -l) -ne 0 ]]; then
+              echo "command should not print anything to succeed:"
+              echo $output
+              exit 1
+          fi
+
+    - script:
+        name: go test
+        code: go test -v $(go list willnorris.com/go/imageproxy/... | grep -v /vendor/)
+
+    - script:
+        name: go build
+        code: |
+          GOOS=linux CGO_ENABLED=0 go build \
+            -a -ldflags '-s' \
+            -installsuffix cgo \
+            -o imageproxy \
+            willnorris.com/go/imageproxy/cmd/imageproxy
+
+    - script:
+        name: copy binary
+        code: cp imageproxy "$WERCKER_OUTPUT_DIR"
+
+deploy-docker:
+    box:
+        id: alpine
+        cmd: /bin/sh
+    steps:
+    - script:
+        name: Install packages
+        code: |
+          apk --no-cache add ca-certificates
+    - internal/docker-push:
+        disable-sync: true
+        username: $DOCKER_USERNAME
+        password: $DOCKER_PASSWORD
+        repository: $DOCKER_OWNER/$WERCKER_GIT_REPOSITORY
+        tag: $WERCKER_GIT_COMMIT, latest, $WERCKER_GIT_BRANCH
+        entrypoint: /pipeline/source/imageproxy
+


### PR DESCRIPTION
Hey hey,

we at CostaDigital are using this imageproxy heavily in production, but we have the need to use ultra lightweight containers. Using a CI tool like wercker and following the approach of micro containers we're able to reduce the docker image size to 10mb (https://hub.docker.com/r/costadigital/imageproxy/tags/ ):

```bash
$ docker images | grep image
costadigital/imageproxy latest 56c466d5701e 9 minutes ago 9.84 MB
``` 
Are you interested in merging this stuff back to your master? You'd just have to create the wercker app for this repo. and configure the env vars properly. Also the push target would need to be changed, right now it would push into the same docker hub repo as the automated build, and I don't know whether that's possible TBH.

Looking forward to your feedback! 💪 

Cheers,
Alex