### PR TITLE
Respond with 200 on /

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -99,6 +99,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return // ignore favicon requests
 	}
 
+	if r.URL.Path == "/" {
+		fmt.Fprint(w, "OK")
+		return
+	}
+
 	if r.URL.Path == "/health-check" {
 		fmt.Fprint(w, "OK")
 		return


### PR DESCRIPTION
I'm using Kubernetes to deploy imageproxy and for a difficult to explain reason the healthchecks are done on `/` by default for `ingress` services on GCE.

It's something that's probably going to get fixed in ingress configs or annotations, but for now this is the only sane way I found to fix the issue.

I realize that this is not very important for imageproxy as it's just a default of deployment, but if it doesn't mess with anything I'd love to push this upstream.

The 'OK' message can be anything.