### PR TITLE
Fix interpretation of `Last-Modified` and `If-Modified-Since` headers

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -262,7 +262,7 @@ func should304(req *http.Request, resp *http.Response) bool {
 	if err != nil {
 		return false
 	}
-	if lastModified.Before(ifModSince) {
+	if lastModified.Before(ifModSince) || lastModified.Equal(ifModSince) {
 		return true
 	}
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -223,8 +223,13 @@ func TestShould304(t *testing.T) {
 			"HTTP/1.1 200 OK\nEtag: \"v\"\n\n",
 			true,
 		},
-		{ // last-modified match
+		{ // last-modified before
 			"GET / HTTP/1.1\nIf-Modified-Since: Sun, 02 Jan 2000 00:00:00 GMT\n\n",
+			"HTTP/1.1 200 OK\nLast-Modified: Sat, 01 Jan 2000 00:00:00 GMT\n\n",
+			true,
+		},
+		{ // last-modified match
+			"GET / HTTP/1.1\nIf-Modified-Since: Sat, 01 Jan 2000 00:00:00 GMT\n\n",
 			"HTTP/1.1 200 OK\nLast-Modified: Sat, 01 Jan 2000 00:00:00 GMT\n\n",
 			true,
 		},


### PR DESCRIPTION
If the dates in `Last-Modified` and `If-Modified-Since` are an exact match, the server should 304.

In practice, most clients use the exact value from `Last-Modified` as the value of `If-Modified-Since` in subsequent requests. This fix should generate significant performance gains for users who request cacheable assets without the use of etags.