### PR TITLE
Build docker image from scratch to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
 FROM golang:1.8
 MAINTAINER Sevki <s@sevki.org>
 
-ADD . /go/src/willnorris.com/go/imageproxy
-RUN go get willnorris.com/go/imageproxy/cmd/imageproxy
+WORKDIR /go/src/willnorris.com/go/imageproxy
+ADD . .
 
-CMD []
-ENTRYPOINT ["/go/bin/imageproxy"]
+WORKDIR /go/src/willnorris.com/go/imageproxy/cmd/imageproxy
+RUN go-wrapper download
+RUN CGO_ENABLED=0 GOOS=linux go-wrapper install
+
+FROM scratch
+
+WORKDIR /go/bin
+
+COPY --from=0 /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=0 /etc/ssl/certs /etc/ssl/certs
+COPY --from=0 /go/bin/imageproxy .
+
+CMD ["-addr", "0.0.0.0:8080"]
+ENTRYPOINT ["/go/bin/imageproxy", "-logtostderr=true"]
 
 EXPOSE 8080


### PR DESCRIPTION
This builds docker image in 2 stage build process and reduces image size to basically the same size as binary.