### PR TITLE
Add "fail secure" mode and client timeout

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -51,6 +51,7 @@ var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their or
 var timeout = flag.Duration("timeout", 0, "time limit for requests served by this proxy")
 var verbose = flag.Bool("verbose", false, "print verbose logging messages")
 var version = flag.Bool("version", false, "Deprecated: this flag does nothing")
+var failsecure = flag.Bool("failsecure", false, "Fail secure: if downstream response is unparseable as an image, return an error")
 
 func init() {
 	flag.Var(&cache, "cache", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")
@@ -89,6 +90,7 @@ func main() {
 	p.Timeout = *timeout
 	p.ScaleUp = *scaleUp
 	p.Verbose = *verbose
+	p.FailSecure = *failsecure
 
 	server := &http.Server{
 		Addr:    *addr,

--- a/data.go
+++ b/data.go
@@ -90,6 +90,9 @@ type Options struct {
 
 	// Automatically find good crop points based on image content.
 	SmartCrop bool
+
+	// Fail Secure -- do not continue if the object is not an images
+	FailSecure bool
 }
 
 func (o Options) String() string {

--- a/data_test.go
+++ b/data_test.go
@@ -31,19 +31,19 @@ func TestOptions_String(t *testing.T) {
 			"0x0",
 		},
 		{
-			Options{1, 2, true, 90, true, true, 80, "", false, "", 0, 0, 0, 0, false},
+			Options{1, 2, true, 90, true, true, 80, "", false, "", 0, 0, 0, 0, false, false},
 			"1x2,fit,r90,fv,fh,q80",
 		},
 		{
-			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 0, 0, 0, 0, false},
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 0, 0, 0, 0, false, false},
 			"0.15x1.3,r45,q95,sc0ffee,png",
 		},
 		{
-			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "", 100, 200, 0, 0, false},
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "", 100, 200, 0, 0, false, false},
 			"0.15x1.3,r45,q95,sc0ffee,cx100,cy200",
 		},
 		{
-			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 100, 200, 300, 400, false},
+			Options{0.15, 1.3, false, 45, false, false, 95, "c0ffee", false, "png", 100, 200, 300, 400, false, false},
 			"0.15x1.3,r45,q95,sc0ffee,png,cx100,cy200,cw300,ch400",
 		},
 	}
@@ -94,19 +94,19 @@ func TestParseOptions(t *testing.T) {
 		{"FOO,1,BAR,r90,BAZ", Options{Width: 1, Height: 1, Rotate: 90}},
 
 		// flags, in different orders
-		{"q70,1x2,fit,r90,fv,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 0, 0, 0, 0, false}},
-		{"r90,fh,sc0ffee,png,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 0, 0, 0, 0, false}},
+		{"q70,1x2,fit,r90,fv,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 0, 0, 0, 0, false, false}},
+		{"r90,fh,sc0ffee,png,q90,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 0, 0, 0, 0, false, false}},
 
 		// all flags, in different orders with crop
-		{"q70,cx100,cw300,1x2,fit,cy200,r90,fv,ch400,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400, false}},
-		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400, false}},
+		{"q70,cx100,cw300,1x2,fit,cy200,r90,fv,ch400,fh,sc0ffee,png", Options{1, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400, false, false}},
+		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,1x2,fv,fit", Options{1, 2, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400, false, false}},
 
 		// all flags, in different orders with crop & different resizes
-		{"q70,cx100,cw300,x2,fit,cy200,r90,fv,ch400,fh,sc0ffee,png", Options{0, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400, false}},
-		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,1x,fv,fit", Options{1, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400, false}},
-		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit", Options{0, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false}},
-		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit,123x321", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false}},
-		{"123x321,ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false}},
+		{"q70,cx100,cw300,x2,fit,cy200,r90,fv,ch400,fh,sc0ffee,png", Options{0, 2, true, 90, true, true, 70, "c0ffee", false, "png", 100, 200, 300, 400, false, false}},
+		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,1x,fv,fit", Options{1, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 300, 400, false, false}},
+		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit", Options{0, 0, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false, false}},
+		{"ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit,123x321", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false, false}},
+		{"123x321,ch400,r90,cw300,fh,sc0ffee,png,cx100,q90,cy200,cw,fv,fit", Options{123, 321, true, 90, true, true, 90, "c0ffee", false, "png", 100, 200, 0, 400, false, false}},
 	}
 
 	for _, tt := range tests {

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -347,6 +347,10 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	opt := ParseOptions(req.URL.Fragment)
 
+	if t.getFailSecure() {
+		opt.FailSecure = true
+	}
+
 	img, err := Transform(b, opt)
 	if err != nil {
 		log.Printf("error transforming image: %v", err)

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -330,6 +330,9 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
+	if t.getFailSecure() && !strings.HasPrefix(resp.Header.Get("Content-Type"), "image/") {
+		return &http.Response{StatusCode: http.StatusForbidden, Body: nopCloser{bytes.NewBufferString("Invalid target content-type")} }, nil
+	}
 
 	if should304(req, resp) {
 		// bare 304 response, full response will be used from cache
@@ -349,7 +352,7 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		log.Printf("error transforming image: %v", err)
 		if t.getFailSecure() {
 			// return a 403
-			return &http.Response{StatusCode: http.StatusForbidden, Body: nopCloser{bytes.NewBufferString("Invalid target")} }, nil
+			return &http.Response{StatusCode: http.StatusForbidden, Body: nopCloser{bytes.NewBufferString("Invalid target content")} }, nil
 		} else {
 			// fall back to old behaviour -- return bytes
 			img = b

--- a/transform.go
+++ b/transform.go
@@ -46,13 +46,19 @@ var resampleFilter = imaging.Lanczos
 // encoded image in one of the supported formats (gif, jpeg, or png).  The
 // bytes of a similarly encoded image is returned.
 func Transform(img []byte, opt Options) ([]byte, error) {
+	// - skip if FailSecure is set, as we still need to test whether this is actually an image before returning
+	if !opt.transform() && !opt.FailSecure {
+		// bail if no transformation was requested
+		return img, nil
+	}
 	// decode image
 	m, format, err := image.Decode(bytes.NewReader(img))
 	if err != nil {
 		return nil, err
 	}
-	
+
 	if !opt.transform() {
+		// if we got here, FailSecure must be set -- so we still needed to test whether this was an image.
 		// bail if no transformation was requested
 		return img, nil
 	}

--- a/transform.go
+++ b/transform.go
@@ -46,15 +46,15 @@ var resampleFilter = imaging.Lanczos
 // encoded image in one of the supported formats (gif, jpeg, or png).  The
 // bytes of a similarly encoded image is returned.
 func Transform(img []byte, opt Options) ([]byte, error) {
-	if !opt.transform() {
-		// bail if no transformation was requested
-		return img, nil
-	}
-
 	// decode image
 	m, format, err := image.Decode(bytes.NewReader(img))
 	if err != nil {
 		return nil, err
+	}
+	
+	if !opt.transform() {
+		// bail if no transformation was requested
+		return img, nil
 	}
 
 	// apply EXIF orientation for jpeg and tiff source images. Read at most


### PR DESCRIPTION
- Adds a -failsecure command line parameter that ensures that the target content is always verified to in fact be an image before returning it to the requester - existing functionality acts as an open http proxy with potential for abuse. Note: added this as a command line option so as not to break existing use cases that may depend on the open proxy logic (i.e. using imageproxy as a backend cache for non-image files).
examples:
- http://localhost:8080/600x/https://www.google.com
- http://localhost:8080/https://www.cnn.com

- applies the Timeout parameter to the http client as well as the server, so as not to leave open connections potentially consuming system resources after we have given up requesting from a slow upstream server.
e.g. run a nonresponsive http server and then try to imageproxy it
- http://localhost:8080/200x/http://localhost:10000/test.jpg

unresponsivevserver.go:
package main
import (
  "net/http"
  "time"
  "log"
)
func main() {
  svr := &http.Server{
    Addr:":10000",
    Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
      time.Sleep(time.Hour)
    }),
  }
  log.Fatal(svr.ListenAndServe())
}


