### PR TITLE
Restricted Content-Types

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -67,6 +67,9 @@ func main() {
 	if *referrers != "" {
 		p.Referrers = strings.Split(*referrers, ",")
 	}
+	if *contentTypes != "" {
+		p.ContentTypes = strings.Split(*contentTypes, ",")
+	}
 	if *signatureKey != "" {
 		key := []byte(*signatureKey)
 		if strings.HasPrefix(*signatureKey, "@") {

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -51,6 +51,7 @@ var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their or
 var timeout = flag.Duration("timeout", 0, "time limit for requests served by this proxy")
 var verbose = flag.Bool("verbose", false, "print verbose logging messages")
 var version = flag.Bool("version", false, "Deprecated: this flag does nothing")
+var contentTypes = flag.String("contentTypes", "", "comma separated list of allowed content types")
 
 func init() {
 	flag.Var(&cache, "cache", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -228,8 +228,8 @@ func (p *Proxy) allowed(r *Request) error {
 // allowedContentType returns an allowed content type string to use in responses or "" if the
 // content type cannot be used.
 func (p *Proxy) allowedContentType(contentType string) string {
-	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil && err != mime.ErrInvalidMediaParameter {
+	mediaType, _, _ := mime.ParseMediaType(contentType)
+	if mediaType == "" {
 		return ""
 	}
 

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -26,8 +26,10 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"mime"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -67,6 +69,10 @@ type Proxy struct {
 
 	// If true, log additional debug messages
 	Verbose bool
+
+	// ContentTypes specifies a list of content types to allow. An empty list means only image types
+	// are allowed.
+	ContentTypes []string
 }
 
 // NewProxy constructs a new proxy.  The provided http RoundTripper will be
@@ -162,7 +168,15 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	copyHeader(w.Header(), resp.Header, "Content-Length", "Content-Type")
+	if contentType := p.allowedContentType(resp.Header.Get("Content-Type")); contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+	} else {
+		http.Error(w, "forbidden content-type", http.StatusForbidden)
+		return
+	}
+
+	copyHeader(w.Header(), resp.Header, "Content-Length")
 
 	//Enable CORS for 3rd party applications
 	w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -209,6 +223,41 @@ func (p *Proxy) allowed(r *Request) error {
 	}
 
 	return fmt.Errorf("request does not contain an allowed host or valid signature: %v", r)
+}
+
+// allowedContentType returns an allowed content type string to use in responses or "" if the
+// content type cannot be used.
+func (p *Proxy) allowedContentType(contentType string) string {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil && err != mime.ErrInvalidMediaParameter {
+		return ""
+	}
+
+	if len(p.ContentTypes) == 0 {
+		switch mediaType {
+		case "image/bmp", "image/cgm", "image/g3fax", "image/gif", "image/ief", "image/jp2",
+			"image/jpeg", "image/jpg", "image/pict", "image/png", "image/prs.btif", "image/svg+xml",
+			"image/tiff", "image/vnd.adobe.photoshop", "image/vnd.djvu", "image/vnd.dwg",
+			"image/vnd.dxf", "image/vnd.fastbidsheet", "image/vnd.fpx", "image/vnd.fst",
+			"image/vnd.fujixerox.edmics-mmr", "image/vnd.fujixerox.edmics-rlc",
+			"image/vnd.microsoft.icon", "image/vnd.ms-modi", "image/vnd.net-fpx", "image/vnd.wap.wbmp",
+			"image/vnd.xiff", "image/webp", "image/x-cmu-raster", "image/x-cmx", "image/x-icon",
+			"image/x-macpaint", "image/x-pcx", "image/x-pict", "image/x-portable-anymap",
+			"image/x-portable-bitmap", "image/x-portable-graymap", "image/x-portable-pixmap",
+			"image/x-quicktime", "image/x-rgb", "image/x-xbitmap", "image/x-xpixmap",
+			"image/x-xwindowdump":
+			return mediaType
+		}
+		return ""
+	}
+
+	for _, pattern := range p.ContentTypes {
+		if ok, err := filepath.Match(pattern, mediaType); ok && err == nil {
+			return mediaType
+		}
+	}
+
+	return ""
 }
 
 // validHost returns whether the host in u matches one of hosts.

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -299,12 +299,12 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var raw string
 
 	switch req.URL.Path {
-	case "/ok":
+	case "/plain":
 		raw = "HTTP/1.1 200 OK\n\n"
 	case "/error":
 		return nil, errors.New("http protocol error")
 	case "/nocontent":
-		raw = "HTTP/1.1 204 No Content\n\n"
+		raw = "HTTP/1.1 204 No Content\nContent-Type: image/png\n\n"
 	case "/etag":
 		raw = "HTTP/1.1 200 OK\nEtag: \"tag\"\n\n"
 	case "/png":
@@ -312,7 +312,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		img := new(bytes.Buffer)
 		png.Encode(img, m)
 
-		raw = fmt.Sprintf("HTTP/1.1 200 OK\nContent-Length: %d\n\n%s", len(img.Bytes()), img.Bytes())
+		raw = fmt.Sprintf("HTTP/1.1 200 OK\nContent-Length: %d\nContent-Type: image/png\n\n%s", len(img.Bytes()), img.Bytes())
 	default:
 		raw = "HTTP/1.1 404 Not Found\n\n"
 	}
@@ -338,8 +338,8 @@ func TestProxy_ServeHTTP(t *testing.T) {
 		{"/http://bad.test/", http.StatusForbidden},                 // Disallowed host
 		{"/http://good.test/error", http.StatusInternalServerError}, // HTTP protocol error
 		{"/http://good.test/nocontent", http.StatusNoContent},       // non-OK response
-
-		{"/100/http://good.test/ok", http.StatusOK},
+		{"/100/http://good.test/png", http.StatusOK},
+		{"/100/http://good.test/plain", http.StatusForbidden}, // non-image response
 	}
 
 	for _, tt := range tests {
@@ -408,6 +408,42 @@ func TestTransformingTransport(t *testing.T) {
 		}
 		if got, want := resp.StatusCode, tt.code; got != want {
 			t.Errorf("RoundTrip(%v) returned status code %d, want %d", tt.url, got, want)
+		}
+	}
+}
+
+func TestAllowedContentType(t *testing.T) {
+	p := &Proxy{}
+
+	for contentType, expected := range map[string]string{
+		"":                   "",
+		"image/png":          "image/png",
+		"image/PNG":          "image/png",
+		"image/PNG; foo=bar": "image/png",
+		"text/html":          "",
+	} {
+		actual := p.allowedContentType(contentType)
+		if actual != expected {
+			t.Errorf("got %v, expected %v for content type: %v", actual, expected, contentType)
+		}
+	}
+}
+
+func TestAllowedContentType_Whitelist(t *testing.T) {
+	p := &Proxy{
+		ContentTypes: []string{"foo/*", "bar/baz"},
+	}
+
+	for contentType, expected := range map[string]string{
+		"":          "",
+		"image/png": "",
+		"foo/asdf":  "foo/asdf",
+		"bar/baz":   "bar/baz",
+		"bar/bazz":  "",
+	} {
+		actual := p.allowedContentType(contentType)
+		if actual != expected {
+			t.Errorf("got %v, expected %v for content type: %v", actual, expected, contentType)
 		}
 	}
 }

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -412,36 +412,28 @@ func TestTransformingTransport(t *testing.T) {
 	}
 }
 
-func TestAllowedContentType(t *testing.T) {
-	p := &Proxy{}
-
-	for contentType, expected := range map[string]string{
-		"":                   "",
-		"image/png":          "image/png",
-		"image/PNG":          "image/png",
-		"image/PNG; foo=bar": "image/png",
-		"text/html":          "",
+func TestValidContentType(t *testing.T) {
+	for contentType, expected := range map[string]bool{
+		"":          false,
+		"image/png": true,
+		"text/html": false,
 	} {
-		actual := p.allowedContentType(contentType)
+		actual := validContentType(nil, contentType)
 		if actual != expected {
 			t.Errorf("got %v, expected %v for content type: %v", actual, expected, contentType)
 		}
 	}
 }
 
-func TestAllowedContentType_Whitelist(t *testing.T) {
-	p := &Proxy{
-		ContentTypes: []string{"foo/*", "bar/baz"},
-	}
-
-	for contentType, expected := range map[string]string{
-		"":          "",
-		"image/png": "",
-		"foo/asdf":  "foo/asdf",
-		"bar/baz":   "bar/baz",
-		"bar/bazz":  "",
+func TestValidContentType_Patterns(t *testing.T) {
+	for contentType, expected := range map[string]bool{
+		"":          false,
+		"image/png": false,
+		"foo/asdf":  true,
+		"bar/baz":   true,
+		"bar/bazz":  false,
 	} {
-		actual := p.allowedContentType(contentType)
+		actual := validContentType([]string{"foo/*", "bar/baz"}, contentType)
 		if actual != expected {
 			t.Errorf("got %v, expected %v for content type: %v", actual, expected, contentType)
 		}


### PR DESCRIPTION
For security purposes, we need to ensure that the proxy is only used to serve images. Serving non-image content opens up a lot of attack surface for phishing, XSS, SSRF, and other nasty tricks. Being labeled "**image**proxy", I was surprised to find out that our proxies were happily serving any arbitrary HTML that was thrown at them.

I'm putting this PR in hoping that we can make the proxy more secure by default and bring it up to par with atmos/camo in this regard.

Our ~~upcoming~~ 4.7 release of [Mattermost](https://github.com/mattermost/mattermost-server) was all set to include built-in support for proxying user-posted images (via this or Camo), but we have a lot of very security-minded customers, so this put a slight wrinkle in our plans.

I've read over all of the related discussion I could find (namely [this](https://github.com/willnorris/imageproxy/issues/53)) and I think this addresses the big concerns except for one:

> initially, I think the default should be to not check (see next point), so that this doesn't become a breaking change for anyone.

I strongly believe this *should* be enabled by default. It shouldn't be viewed as simply being a breaking change. It's a security patch. It's supposed to prevent people from doing things that they could do before.

**The Changes**

* By default, the proxy will never return a Content-Type that isn't one of Camo's whitelisted image types. Their whitelist hasn't changed in 4 years and seems like a good, stable reference point.
* If users are relying on the ability to proxy non-image types, they can specify them via the new `-contentTypes` flag. Shell pattern matching is used, so you can do things like `-contentTypes image/*,video/mp4` if you'd like. Or you can just enable everything with wildcards to get today's behavior, but probably no one should do this.

This alters the behavior at the last moment, right before sending the response back to the client. This does not do sniffing. As stated in some of the other discussion, sniffing is pointless in the context of security. The only thing that matters is how browsers interpret the content. And browsers decide that based on the Content-Type and X-Content-Type-Options headers, which are now both set and strictly controlled.