### PR TITLE
Include image URL in transform error log message

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -330,7 +330,7 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	img, err := Transform(b, opt)
 	if err != nil {
-		log.Printf("error transforming image: %v", err)
+		log.Printf("error transforming image %s: %v", u.String(), err)
 		img = b
 	}
 


### PR DESCRIPTION
The default error message does not include the problematic URL so it's hard for admin to find issues. This PR simply includes the URL in the log output.