### PR TITLE
fix XSS and potential SSRF

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -330,8 +330,8 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	img, err := Transform(b, opt)
 	if err != nil {
-		log.Printf("error transforming image %s: %v", u.String(), err)
-		img = b
+		// probablyt not an image will not proxy
+		return nil, fmt.Errorf("error transforming image %s: %v", u.String(), err)
 	}
 
 	// replay response with transformed image and updated content length


### PR DESCRIPTION
this means that if the requested resource is not an image it will not proxy it, but as this is called `imageproxy` I think this should be the default behavior.