### PR TITLE
fixed tcp_mem resource leak when sending 304

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -315,12 +315,13 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 		return nil, err
 	}
 
+	defer resp.Body.Close()
+
 	if should304(req, resp) {
 		// bare 304 response, full response will be used from cache
 		return &http.Response{StatusCode: http.StatusNotModified}, nil
 	}
 
-	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Our server's kernel would unexpectedly report

> TCP: out of memory -- consider tuning tcp_mem

after a while, while the RAM itself was fine. 
After a bit of digging, and a process of elimination of what had changed over the past few days, we suspected a program must be keeping TCP connections open, thus leaking tcp_mem. We tracked it down to being this line, and we have been running a container with this fix in production all day, without any significant raises in tcp_mem allocation (monitoring /proc/net/sockstat).