### PR TITLE
Allow overriding the Logger used by Proxy

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -30,7 +30,6 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -99,8 +98,7 @@ func NewProxy(transport http.RoundTripper, cache Cache) *Proxy {
 	}
 
 	proxy := &Proxy{
-		Cache:  cache,
-		Logger: log.New(os.Stderr, "", log.LstdFlags),
+		Cache: cache,
 	}
 
 	client := new(http.Client)
@@ -376,12 +374,16 @@ func should304(req *http.Request, resp *http.Response) bool {
 func (p *Proxy) log(v ...interface{}) {
 	if p.Logger != nil {
 		p.Logger.Print(v...)
+	} else {
+		log.Print(v...)
 	}
 }
 
 func (p *Proxy) logf(format string, v ...interface{}) {
 	if p.Logger != nil {
 		p.Logger.Printf(format, v...)
+	} else {
+		log.Printf(format, v...)
 	}
 }
 


### PR DESCRIPTION
Related to #162, I'd like a bit more control over the image proxy's log output so that we can route it through the same logging interface that's used by the rest of our server. That's not currently possible because the `Proxy` uses the global `log.Logger` instance, but it's easy enough to get this functionality by giving the `Proxy` it's own `log.Logger` instance. By default, it creates its own instance that matches the one in the `log` package. I'm hoping that this could be useful to others.

There's a few places where the global logger is still used, but that's inside functions that aren't part of the `Proxy` and in the `httpservice.Cache` implementations, so changing those would be more intrusive.