### PR TITLE
Fix signature documentation link location

### DIFF
--- a/data.go
+++ b/data.go
@@ -227,7 +227,7 @@ func (o Options) transform() bool {
 // sign the remote URL in the request.  The HMAC key used to verify signatures is
 // provided to the imageproxy server on startup.
 //
-// See https://github.com/willnorris/imageproxy/wiki/URL-signing
+// See https://github.com/willnorris/imageproxy/blob/master/docs/url-signing.md
 // for examples of generating signatures.
 //
 // Examples


### PR DESCRIPTION
Correct link from non-existent wiki page to new doc location on master
branch.