### PR TITLE
Support for better content type detection with images on S3

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -189,7 +189,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	contentType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
-	if contentType == "" {
+	if contentType == "" || contentType == "application/octet-stream" || contentType == "binary/octet-stream" {
 		// try to detect content type
 		b := bufio.NewReader(resp.Body)
 		resp.Body = ioutil.NopCloser(b)


### PR DESCRIPTION
Brings in support for detecting Content-Type when the Content-Type header equals `application/octet-stream` or `binary/octet-stream`, which is the default mime type on S3. We're using imageproxy as an SSL proxy for remote images in emails, and encounter these two headers quite frequently. We use the default allowed mime type setting.

I'm open to updating this PR to enable via a flag or some other means, and any other changes. Please advise.

An alternative would be to create a flag `-alwaysPeekContent` that always peeks at the content returned, which could be more secure for our use case. I'm open to doing it this way too.