### PR TITLE
option to override remote image expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ additional image adjustment options.
 
 imageproxy URLs are of the form `http://localhost/{options}/{remote_url}`.
 
+## Override request expires ##
+To manually override the remote image expiration :
+
+```
+imageproxy -override-cache-control="public" -override-expires="Sat, 28 Dec 2199 04:09:32 GMT"
+```
+
 ### Options ###
 
 Options are available for cropping, resizing, rotation, flipping, and digital

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -55,6 +55,8 @@ var verbose = flag.Bool("verbose", false, "print verbose logging messages")
 var version = flag.Bool("version", false, "Deprecated: this flag does nothing")
 var contentTypes = flag.String("contentTypes", "image/*", "comma separated list of allowed content types")
 var userAgent = flag.String("userAgent", "willnorris/imageproxy", "specify the user-agent used by imageproxy when fetching images from origin website")
+var overrideCacheControl = flag.String("override-cache-control", "", "manually override the remote website Cache-Control header. for more info see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control")
+var overrideExpires = flag.String("override-expires", "", "manually override the remote website expires header in form of Sat, 28 Dec 2019 04:09:32 GMT")
 
 func init() {
 	flag.Var(&cache, "cache", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")
@@ -64,7 +66,15 @@ func main() {
 	envy.Parse("IMAGEPROXY")
 	flag.Parse()
 
-	p := imageproxy.NewProxy(nil, cache.Cache)
+	overrideOpts := map[string]string{}
+	if *overrideCacheControl != "" {
+		overrideOpts["Cache-Control"] = *overrideCacheControl
+	}
+	if *overrideExpires != "" {
+		overrideOpts["Expires"] = *overrideExpires
+	}
+
+	p := imageproxy.NewProxy(nil, cache.Cache, overrideOpts)
 	if *allowHosts != "" {
 		p.AllowHosts = strings.Split(*allowHosts, ",")
 	}

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -84,12 +84,16 @@ type Proxy struct {
 
 	// The User-Agent used by imageproxy when requesting origin image
 	UserAgent string
+
+	// Request header override key values. provided by user. (for example Expires)
+	HeaderOverrides map[string]string
 }
 
 // NewProxy constructs a new proxy.  The provided http RoundTripper will be
 // used to fetch remote URLs.  If nil is provided, http.DefaultTransport will
 // be used.
-func NewProxy(transport http.RoundTripper, cache Cache) *Proxy {
+// overrideHeader are key/values to override the request headers, such as expires
+func NewProxy(transport http.RoundTripper, cache Cache, overrideHeader map[string]string) *Proxy {
 	if transport == nil {
 		transport = http.DefaultTransport
 	}
@@ -183,6 +187,10 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 
 	copyHeader(w.Header(), resp.Header, "Cache-Control", "Last-Modified", "Expires", "Etag", "Link")
 
+	for k, v := range p.HeaderOverrides {
+		p.logf("overriding request header %s:%s", k, v)
+		resp.Header.Set(k, v)
+	}
 	if should304(r, resp) {
 		w.WriteHeader(http.StatusNotModified)
 		return

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -166,7 +166,7 @@ func TestAllowed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		p := NewProxy(nil, nil)
+		p := NewProxy(nil, nil, map[string]string{})
 		p.AllowHosts = tt.allowHosts
 		p.DenyHosts = tt.denyHosts
 		p.SignatureKey = tt.key


### PR DESCRIPTION
## This PR:

Gives user the option to override the remote image hosting's expire date.

```
imageproxy -override-cache-control="public" -override-expires="Sat, 28 Dec 2199 04:09:32 GMT"
```

closes https://github.com/willnorris/imageproxy/issues/207