### PR TITLE
added validuntil option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ vendor/**/CONTRIBUTORS
 vendor/**/Makefile
 vendor/**/*_ZH.md
 vendor/**/*.sh
+
+cmd/imageproxy*/imageproxy*

--- a/cmd/imageproxy-sign/main_test.go
+++ b/cmd/imageproxy-sign/main_test.go
@@ -131,6 +131,9 @@ func TestParseURL(t *testing.T) {
 		// ensure signature values are stripped
 		{"http://localhost:8080/sc0ffee/http://example.com/", "http://example.com/#0x0"},
 		{"http://example.com/#sc0ffee", "http://example.com/#0x0"},
+
+		// validuntil
+		{"http://localhost:8080/vu20200304/http://example.com/", "http://example.com/#0x0,vu20200304"},
 	}
 
 	for _, tt := range tests {

--- a/data.go
+++ b/data.go
@@ -41,6 +41,7 @@ const (
 	optCropWidth       = "cw"
 	optCropHeight      = "ch"
 	optSmartCrop       = "sc"
+	optValidUntil      = "vu"
 )
 
 // URLError reports a malformed URL error.
@@ -91,6 +92,9 @@ type Options struct {
 
 	// Automatically find good crop points based on image content.
 	SmartCrop bool
+
+	// Check if the URL is still valid in conjunction with a signature you can not change validity of a request.
+	ValidUntil int
 }
 
 func (o Options) String() string {
@@ -134,7 +138,12 @@ func (o Options) String() string {
 	if o.SmartCrop {
 		opts = append(opts, optSmartCrop)
 	}
+	if o.ValidUntil > 0 {
+		opts = append(opts, fmt.Sprintf("%s%d", optValidUntil, o.ValidUntil))
+	}
+
 	sort.Strings(opts)
+
 	return strings.Join(opts, ",")
 }
 
@@ -230,6 +239,11 @@ func (o Options) transform() bool {
 // See https://github.com/willnorris/imageproxy/blob/master/docs/url-signing.md
 // for examples of generating signatures.
 //
+// Validity
+//
+// The "vu{date}" option specifies a date until the request is valid. Please keep in mind
+// to not harm your browser caching TTL settings.
+//
 // Examples
 //
 // 	0x0         - no resizing
@@ -283,6 +297,9 @@ func ParseOptions(str string) Options {
 		case strings.HasPrefix(opt, optCropHeight):
 			value := strings.TrimPrefix(opt, optCropHeight)
 			options.CropHeight, _ = strconv.ParseFloat(value, 64)
+		case strings.HasPrefix(opt, optValidUntil):
+			value := strings.TrimPrefix(opt, optValidUntil)
+			options.ValidUntil, _ = strconv.Atoi(value)
 		case strings.Contains(opt, optSizeDelimiter):
 			size := strings.SplitN(opt, optSizeDelimiter, 2)
 			if w := size[0]; w != "" {


### PR DESCRIPTION
I needed some kind of TTL for the URL, so it is possible to expire public URLs to an image, so passing image URLs around and requesting the image is not possible an infinite time.
My simple approach was to add a validUntil Parameter to the Options 
```
vu{date:20060102}
```
I added the option to the signature so it is not possible to change the validity of the URL.
For my use-case it is ok if images are only valid a single day. otherwise you would have to put some thought into URL generation in your own app to always use the same date, so browser caching would be possible longer than a single day.

What do you think?