### PR TITLE
Fix dockerhub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ a look at [this GitHub repo](https://github.com/oreillymedia/prototype-imageprox
 
 ### Docker ###
 
-A docker image is available at [`willnorris/imageproxy`](https://registry.hub.docker.com/u/willnorris/imageproxy/dockerfile/).
+A docker image is available at [`willnorris/imageproxy`](https://registry.hub.docker.com/r/willnorris/imageproxy).
 
 You can run it by
 ```


### PR DESCRIPTION
The current link goes to a blank page for me.