### PR TITLE
Limit number of the transformations threads

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -153,7 +153,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	timer := prometheus.NewTimer(metricRequestDuration)
-	defer timer.ObserveDuration()
+	metricRequestsInFlight.Inc()
+	defer func() {
+		timer.ObserveDuration()
+		metricRequestsInFlight.Dec()
+	}()
+
 	h.ServeHTTP(w, r)
 }
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -492,6 +492,7 @@ func TestTransformingTransport(t *testing.T) {
 	tr := &TransformingTransport{
 		Transport:     testTransport{},
 		CachingClient: client,
+		limiter:       make(chan struct{}, 1),
 	}
 	client.Transport = tr
 

--- a/metrics.go
+++ b/metrics.go
@@ -26,6 +26,11 @@ var (
 		Name:      "request_duration_seconds",
 		Help:      "Request response times",
 	})
+	metricRequestsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "http",
+		Name:      "requests_in_flight",
+		Help:      "Number of requests in flight",
+	})
 )
 
 func init() {
@@ -33,4 +38,5 @@ func init() {
 	prometheus.MustRegister(metricServedFromCache)
 	prometheus.MustRegister(metricRemoteErrors)
 	prometheus.MustRegister(metricRequestDuration)
+	prometheus.MustRegister(metricRequestsInFlight)
 }


### PR DESCRIPTION
When a search bot requests many images at the same time and these images are not in the cache, all transformation goroutines start in parallel causing the huge memory allocation, that leads to the termination of the process by OOM.

This fix is adding the limiter in the `TransformingTransport` that limits the number of running transformation threads to the number of logical CPUs. The metric `http_requests_in_flight` is adding as well to monitor the length of the requests queue.

Fixes #200.