### PR TITLE
Allow allowing/blocks hosts by IP range

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ prefix a host value with `*.` to allow or deny all sub-domains. You can
 also specify a netblock in CIDR notation (`127.0.0.0/8`) -- this is useful for
 blocking reserved ranges like `127.0.0.0/8`, `192.168.0.0/16`, etc.
 
-If a host matches both an allowed a denied host, the request will be denied.
+If a host matches both an allowed and denied host, the request will be denied.
 
 ### Allowed Content-Type List ###
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,11 @@ Alternately, try running:
 Reloading the [codercat URL][] will still return an error message.
 
 You can specify multiple hosts as a comma separated list to either flag, or
-prefix a host value with `*.` to allow or deny all sub-domains as well.
+prefix a host value with `*.` to allow or deny all sub-domains. You can
+also specify a netblock in CIDR notation (`127.0.0.0/8`) -- this is useful for
+blocking reserved ranges like `127.0.0.0/8`, `192.168.0.0/16`, etc.
 
-If a host matches both an allowed an a denied host, the request will be denied.
+If a host matches both an allowed a denied host, the request will be denied.
 
 ### Allowed Content-Type List ###
 

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -330,7 +330,7 @@ func hostMatches(hosts []string, u *url.URL) bool {
 			// Checks whether our current host is a CIDR
 			if _, ipnet, err := net.ParseCIDR(host); err == nil {
 				// Checks if our host contains the IP in u
-				if ok := ipnet.Contains(ip) == true; ok {
+				if ipnet.Contains(ip) {
 					return true
 				}
 			}

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"log"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -323,6 +324,16 @@ func hostMatches(hosts []string, u *url.URL) bool {
 		}
 		if strings.HasPrefix(host, "*.") && strings.HasSuffix(u.Host, host[2:]) {
 			return true
+		}
+		// Checks whether the host in u is an IP
+		if ip := net.ParseIP(u.Host); ip != nil {
+			// Checks whether our current host is a CIDR
+			if _, ipnet, err := net.ParseCIDR(host); err == nil {
+				// Checks if our host contains the IP in u
+				if ok := ipnet.Contains(ip) == true; ok {
+					return true
+				}
+			}
 		}
 	}
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -172,6 +172,7 @@ func TestAllowed(t *testing.T) {
 		{"http://test/image", emptyOptions, nil, []string{"test"}, nil, nil, nil, false},
 		{"http://test/image", emptyOptions, []string{"test"}, []string{"test"}, nil, nil, nil, false},
 		{"http://test/image", Options{Signature: "NDx5zZHx7QfE8E-ijowRreq6CJJBZjwiRfOVk_mkfQQ="}, nil, []string{"test"}, nil, key, nil, false},
+		{"http://127.0.0.1/image", emptyOptions, nil, []string{"127.0.0.0/8"}, nil, nil, nil, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Give `allowHosts` and `denyHosts` the ability to allow/block based on a netblock. We're using this change to block the reserved IP ranges to prevent users from trying to proxy images from those ranges.