### PR TITLE
Add option to disable following redirects

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -48,6 +48,7 @@ var allowHosts = flag.String("allowHosts", "", "comma separated list of allowed 
 var denyHosts = flag.String("denyHosts", "", "comma separated list of denied remote hosts")
 var referrers = flag.String("referrers", "", "comma separated list of allowed referring hosts")
 var includeReferer = flag.Bool("includeReferer", false, "include referer header in remote requests")
+var followRedirects = flag.Bool("followRedirects", true, "follow redirects")
 var baseURL = flag.String("baseURL", "", "default base URL for relative remote URLs")
 var cache tieredCache
 var signatureKeys signatureKeyList
@@ -90,6 +91,7 @@ func main() {
 	}
 
 	p.IncludeReferer = *includeReferer
+	p.FollowRedirects = *followRedirects
 	p.Timeout = *timeout
 	p.ScaleUp = *scaleUp
 	p.Verbose = *verbose

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -63,6 +63,9 @@ type Proxy struct {
 	// is included in remote requests.
 	IncludeReferer bool
 
+	// FollowRedirects controls whether imageproxy will follow redirects or not.
+	FollowRedirects bool
+
 	// DefaultBaseURL is the URL that relative remote URLs are resolved in
 	// reference to.  If nil, all remote URLs specified in requests must be
 	// absolute.
@@ -185,6 +188,11 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if p.IncludeReferer {
 		// pass along the referer header from the original request
 		copyHeader(actualReq.Header, r.Header, "referer")
+	}
+	if !p.FollowRedirects {
+		p.Client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
 	}
 	resp, err := p.Client.Do(actualReq)
 

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -287,7 +287,7 @@ var (
 	errDeniedHost = errors.New("request contains a denied host")
 	errNotAllowed = errors.New("request does not contain an allowed host or valid signature")
 
-	msgNotAllowed = "requested URL is not allowed"
+	msgNotAllowed           = "requested URL is not allowed"
 	msgNotAllowedInRedirect = "requested URL in redirect is not allowed"
 )
 

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -192,7 +192,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if p.FollowRedirects {
 		// FollowRedirects is true (default), ensure that the redirected host is allowed
 		p.Client.CheckRedirect = func(newreq *http.Request, via []*http.Request) error {
-			if hostMatches(p.DenyHosts, newreq.URL) || hostMatches(p.AllowHosts, newreq.URL) {
+			if hostMatches(p.DenyHosts, newreq.URL) || (len(p.AllowHosts) > 0 && !hostMatches(p.AllowHosts, newreq.URL)) {
 				http.Error(w, msgNotAllowedInRedirect, http.StatusForbidden)
 				return errNotAllowed
 			}

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -192,7 +192,6 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	if p.FollowRedirects {
 		// FollowRedirects is true (default), ensure that the redirected host is allowed
 		p.Client.CheckRedirect = func(newreq *http.Request, via []*http.Request) error {
-			fmt.Printf("%v", newreq.URL)
 			if hostMatches(p.DenyHosts, newreq.URL) || hostMatches(p.AllowHosts, newreq.URL) {
 				http.Error(w, msgNotAllowedInRedirect, http.StatusForbidden)
 				return errNotAllowed


### PR DESCRIPTION
Adds a new `FollowRedirects` flag that defaults to `true`. If the user sets it to `false`, imageproxy will not follow redirects and instead will use the content of the redirect (likely `text/html` which will result in a 403 due to the default allowed `content-type`s list).

If you are electing to follow redirects, ensure that the host being redirected to is allowed per `AllowHosts` and `DenyHosts`. Without this, you can use a redirect to get around the `allowed()` logic.