### PR TITLE
Switch to Hostname() to strip the port while running through hostMatches()

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -319,14 +319,14 @@ func contentTypeMatches(patterns []string, contentType string) bool {
 // hostMatches returns whether the host in u matches one of hosts.
 func hostMatches(hosts []string, u *url.URL) bool {
 	for _, host := range hosts {
-		if u.Host == host {
+		if u.Hostname() == host {
 			return true
 		}
-		if strings.HasPrefix(host, "*.") && strings.HasSuffix(u.Host, host[2:]) {
+		if strings.HasPrefix(host, "*.") && strings.HasSuffix(u.Hostname(), host[2:]) {
 			return true
 		}
 		// Checks whether the host in u is an IP
-		if ip := net.ParseIP(u.Host); ip != nil {
+		if ip := net.ParseIP(u.Hostname()); ip != nil {
 			// Checks whether our current host is a CIDR
 			if _, ipnet, err := net.ParseCIDR(host); err == nil {
 				// Checks if our host contains the IP in u

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -170,9 +170,11 @@ func TestAllowed(t *testing.T) {
 
 		// deny requests that match denyHosts, even if signature is valid or also matches allowHosts
 		{"http://test/image", emptyOptions, nil, []string{"test"}, nil, nil, nil, false},
+		{"http://test:3000/image", emptyOptions, nil, []string{"test"}, nil, nil, nil, false},
 		{"http://test/image", emptyOptions, []string{"test"}, []string{"test"}, nil, nil, nil, false},
 		{"http://test/image", Options{Signature: "NDx5zZHx7QfE8E-ijowRreq6CJJBZjwiRfOVk_mkfQQ="}, nil, []string{"test"}, nil, key, nil, false},
 		{"http://127.0.0.1/image", emptyOptions, nil, []string{"127.0.0.0/8"}, nil, nil, nil, false},
+		{"http://127.0.0.1:3000/image", emptyOptions, nil, []string{"127.0.0.0/8"}, nil, nil, nil, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is my last one, I promise. 😬

Using `.Host` allows you to get around a `denyHosts` entry by adding a port, `Hostname()` strips the port.

(Unrelated thought I had while testing this, I wonder if `www` is worthy of being a special-cased subdomain that is automatically denied if the root is in `denyHosts`?)