### PR TITLE
Support proxying images with no provided intermediate cert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11
 	github.com/disintegration/imaging v1.6.0
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/fcjr/aia-transport-go v1.2.1 // indirect
+	github.com/fcjr/aia-transport-go v1.2.1
 	github.com/garyburd/redigo v1.6.0
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -50,5 +50,3 @@ replace (
 )
 
 go 1.13
-
-replace github.com/fcjr/aia-transport-go v1.2.1 => github.com/blakestoddard/aia-transport-go v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11
 	github.com/disintegration/imaging v1.6.0
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
+	github.com/fcjr/aia-transport-go v1.2.1 // indirect
 	github.com/garyburd/redigo v1.6.0
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -49,3 +50,5 @@ replace (
 )
 
 go 1.13
+
+replace github.com/fcjr/aia-transport-go v1.2.1 => github.com/blakestoddard/aia-transport-go v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blakestoddard/aia-transport-go v1.2.1/go.mod h1:onSqSq3tGkM14WusDx7q9FTheS9R1KBtD+QBWI6zG/w=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -49,6 +50,8 @@ github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyG
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/fcjr/aia-transport-go v1.2.1 h1:a40mu8FRRXZy45aTb8uWh9I9h+R6Roewa8+OA/wYHPo=
+github.com/fcjr/aia-transport-go v1.2.1/go.mod h1:onSqSq3tGkM14WusDx7q9FTheS9R1KBtD+QBWI6zG/w=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/garyburd/redigo v1.6.0 h1:0VruCpn7yAIIu7pWVClQC8wxCJEcG3nyzpMSHKi1PQc=

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/fcjr/aia-transport-go"
 	"io"
 	"io/ioutil"
 	"log"
@@ -99,7 +100,7 @@ type Proxy struct {
 // be used.
 func NewProxy(transport http.RoundTripper, cache Cache) *Proxy {
 	if transport == nil {
-		transport = http.DefaultTransport
+		transport, _ = aia.NewTransport()
 	}
 	if cache == nil {
 		cache = NopCache


### PR DESCRIPTION
I've run across several customer issues over the last few days where the provider sending them content is serving images from a domain without their intermediate cert in the chain. This leads to this wonderful error while trying to load the image:
```
x509: certificate signed by unknown authority
```

`openssl` [doesn't complete intermediate cert chains](https://github.com/openssl/openssl/issues/5168) (and neither does `net/http`), instead opting to toss it off to the app to take care of. This isn't an issue in the browser (or cURL) because they take care of finishing out the cert and verifying it (and Windows does, funnily enough -- macOS and Linux do not).

But! Someone has already solved this issue for `net/http`: https://github.com/fcjr/aia-transport-go

This PR swaps the `http.DefaultTransport` struct for one provided by `aia-transport-go` that can finish fetching and verifying intermediate certificates.

(I don't have an example image unfortunately, I've been troubleshooting with customer-provided images as they write in.)