### PR TITLE
Add JSON log output support via logrus

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"os"
@@ -55,6 +55,7 @@ var signatureKeys signatureKeyList
 var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their original dimensions")
 var timeout = flag.Duration("timeout", 0, "time limit for requests served by this proxy")
 var verbose = flag.Bool("verbose", false, "print verbose logging messages")
+var logFormat = flag.String("logFormat", "ascii", "format to output logs in, ascii or json")
 var _ = flag.Bool("version", false, "Deprecated: this flag does nothing")
 var contentTypes = flag.String("contentTypes", "image/*", "comma separated list of allowed content types")
 var userAgent = flag.String("userAgent", "willnorris/imageproxy", "specify the user-agent used by imageproxy when fetching images from origin website")
@@ -67,6 +68,11 @@ func init() {
 func main() {
 	envy.Parse("IMAGEPROXY")
 	flag.Parse()
+
+	if *logFormat == "json" {
+		// Log as JSON instead of the default ASCII formatter.
+		log.SetFormatter(&log.JSONFormatter{})
+	}
 
 	p := imageproxy.NewProxy(nil, cache.Cache)
 	if *allowHosts != "" {

--- a/data.go
+++ b/data.go
@@ -91,6 +91,9 @@ type Options struct {
 
 	// Automatically find good crop points based on image content.
 	SmartCrop bool
+
+	// Generated transaction ID for logging identification
+	TransactionId string
 }
 
 func (o Options) String() string {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/fcjr/aia-transport-go v1.2.1
 	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/jamiealquiza/envy v1.1.0
@@ -23,6 +24,7 @@ require (
 	github.com/prometheus/common v0.13.0 // indirect
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/satori/go.uuid v0.0.0-20180103174451-36e9d2ebbde5 // indirect
+	github.com/sirupsen/logrus v1.7.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	golang.org/x/image v0.0.0-20200801110659-972c09e46d76
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
@@ -394,6 +396,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
+github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -559,6 +563,7 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/transform.go
+++ b/transform.go
@@ -22,7 +22,7 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"math"
 
 	"github.com/disintegration/imaging"
@@ -182,7 +182,8 @@ func cropParams(m image.Image, opt Options) image.Rectangle {
 		h := evaluateFloat(opt.Height, imgH)
 		r, err := smartcropAnalyzer.FindBestCrop(m, w, h)
 		if err != nil {
-			log.Printf("smartcrop error finding best crop: %v", err)
+			log.WithField("transactionId", opt.TransactionId).Info(
+				fmt.Sprintf("smartcrop error finding best crop: %v", err))
 		} else {
 			return r
 		}


### PR DESCRIPTION
First pass at adding JSON log output support + traceable transaction IDs (in the form of a UUID-based `X-Request-ID`) that allows you to tie _most_ log lines to a given request.

This gets a little messy because there is no central log context. Logrus has an example of setting a program-wide field to include, but it doesn't work with something that changes so often (like a transaction ID that changes on every received request). Notably missing here is lack of support for including the transaction ID in log lines from the S3 and GCS cache implementations because I didn't have a way to pass the transaction ID and didn't want to use a global var.

This was really a proof of concept for our own internal usage since we front ImageProxy with nginx for better visibility into how long ImageProxy requests are taking. With these changes, we'll have a way to link nginx logs (we use the standard ECS format) with ImageProxy logs via the transaction ID.

I'd love some feedback here -- whether that's telling me that I'm doing this all wrong and need to start over, or that I should keep this in my own fork, either is okay 😂

Before:
```
./imageproxy -verbose
imageproxy listening on localhost:8080
2020/10/01 14:41:32 fetching remote URL: https://images.apple.com/dm/us/20/1E6B8898-11AD-45E2-92A9-B108787F5756/i/offer_hero_2x.png
2020/10/01 14:41:33 request: {Method:GET URL:https://images.apple.com/dm/us/20/1E6B8898-11AD-45E2-92A9-B108787F5756/i/offer_hero_2x.png#0x0 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept:[image/*] User-Agent:[willnorris/imageproxy]] Body:<nil> GetBody:<nil> ContentLength:0 TransferEncoding:[] Close:false Host:images.apple.com Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr: RequestURI: TLS:<nil> Cancel:<nil> Response:<nil> ctx:0xc0000340f0} (served from cache: false)
```

After:
```
./imageproxy -verbose -logFormat json
imageproxy listening on localhost:8080
{"level":"info","msg":"fetching remote URL: https://images.apple.com/dm/us/20/1E6B8898-11AD-45E2-92A9-B108787F5756/i/offer_hero_2x.png","time":"2020-10-01T17:16:01-04:00","transaction":"d8724bf1-fc0e-4822-b7d5-f9b58dcbe5e1"}
{"level":"info","msg":"request: {Method:GET URL:https://images.apple.com/dm/us/20/1E6B8898-11AD-45E2-92A9-B108787F5756/i/offer_hero_2x.png#0x0 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept:[image/*] User-Agent:[willnorris/imageproxy] X-Request-Id:[d8724bf1-fc0e-4822-b7d5-f9b58dcbe5e1]] Body:\u003cnil\u003e GetBody:\u003cnil\u003e ContentLength:0 TransferEncoding:[] Close:false Host:images.apple.com Form:map[] PostForm:map[] MultipartForm:\u003cnil\u003e Trailer:map[] RemoteAddr: RequestURI: TLS:\u003cnil\u003e Cancel:\u003cnil\u003e Response:\u003cnil\u003e ctx:0xc00012c008} (served from cache: false)","time":"2020-10-01T17:16:02-04:00","transaction":"d8724bf1-fc0e-4822-b7d5-f9b58dcbe5e1"}
```