### PR TITLE
Set a strict Content-Security-Policy by default

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -252,6 +252,9 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	// Enable CORS for 3rd party applications
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
+	// Add a Content-Security-Policy to prevent stored-XSS attacks via SVG files
+	w.Header().Set("Content-Security-Policy", "script-src 'none'")
+
 	w.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		p.logf("error copying response: %v", err)

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -255,6 +255,9 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	// Add a Content-Security-Policy to prevent stored-XSS attacks via SVG files
 	w.Header().Set("Content-Security-Policy", "script-src 'none'")
 
+	// Disable Content-Type sniffing
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	w.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		p.logf("error copying response: %v", err)


### PR DESCRIPTION
Customer-provided SVGs can turn ImageProxy into somewhat of an attack vector via a Stored XSS attack. I'm not clear on an actual attack method using this vulnerability, but it's been reported to us several times as part of our security bounty program, so here's a fix.

Example: https://raw.githubusercontent.com/swisskyrepo/PayloadsAllTheThings/404afd1d719b59c2a7600b83b5ed4583f8c822e9/XSS%20Injection/Files/SVG_XSS.svg (proxy ^, should open a Javascript Prompt without the CSP header)