### PR TITLE
Delegate Content-Type verification solely to contentTypeMatches()

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -180,11 +180,9 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 	req.Options.ScaleUp = p.ScaleUp
 
 	actualReq, _ := http.NewRequest("GET", req.String(), nil)
+	actualReq.Header.Set("Accept", "*/*")
 	if p.UserAgent != "" {
 		actualReq.Header.Set("User-Agent", p.UserAgent)
-	}
-	if len(p.ContentTypes) != 0 {
-		actualReq.Header.Set("Accept", strings.Join(p.ContentTypes, ", "))
 	}
 	if p.IncludeReferer {
 		// pass along the referer header from the original request

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -181,6 +181,7 @@ func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
 
 	actualReq, _ := http.NewRequest("GET", req.String(), nil)
 	actualReq.Header.Set("Accept", "*/*")
+	actualReq.Header.Set("Accept-Language", "*")
 	if p.UserAgent != "" {
 		actualReq.Header.Set("User-Agent", p.UserAgent)
 	}


### PR DESCRIPTION
Image content returned from the initial request will have its `Content-Type` verified at https://github.com/willnorris/imageproxy/blob/main/imageproxy.go#L243. Prefilling the `Accept` header with the list of accepted `Content-Type`'s has proven troublesome for some of our customers as some web servers have odd behaviors like:
- returning an error if you provide a list of `Content-Type`s in `Accept`
- returning an error if you provide a `Content-Type` in `Accept` that the server does not know about (like `image`, which is not valid normally, but some web servers return content using that Content-Type 🙃)