### PR TITLE
Add support for UNIX domain socket

### DIFF
--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,7 +44,7 @@ import (
 
 const defaultMemorySize = 100
 
-var addr = flag.String("addr", "localhost:8080", "TCP address to listen on")
+var addr = flag.String("addr", "localhost:8080", "address to listen on, could be either a TCP address or a UNIX domain socket path prefixed with unix:")
 var allowHosts = flag.String("allowHosts", "", "comma separated list of allowed remote hosts")
 var denyHosts = flag.String("denyHosts", "", "comma separated list of denied remote hosts")
 var referrers = flag.String("referrers", "", "comma separated list of allowed referring hosts")
@@ -97,15 +98,25 @@ func main() {
 	p.Verbose = *verbose
 	p.UserAgent = *userAgent
 
-	server := &http.Server{
-		Addr:    *addr,
-		Handler: p,
-	}
-
 	r := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	r.PathPrefix("/").Handler(p)
-	fmt.Printf("imageproxy listening on %s\n", server.Addr)
-	log.Fatal(http.ListenAndServe(*addr, r))
+
+	fmt.Printf("imageproxy listening on %s\n", *addr)
+
+	var listener net.Listener
+	var err error
+
+	if strings.HasPrefix(*addr, "unix:") {
+		listener, err = net.Listen("unix", (*addr)[5:])
+	} else {
+		listener, err = net.Listen("tcp", *addr)
+	}
+
+	if err != nil {
+		log.Fatalf("listen failed: %v", err)
+	}
+
+	log.Fatal(http.Serve(listener, r))
 }
 
 type signatureKeyList [][]byte


### PR DESCRIPTION
This PR adds UNIX domain socket support for the addr option.

I want this as I run all my services behind nginx with unix domain socket.
I suppose there are more reasons someone would want to run 
imageproxy without listening to a TCP port.

I never wrote any Go before this PR, I hope I haven't done anything stupid...