### PR TITLE
Add Aliyun OSS cache support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ imageproxy is a caching image proxy server written in go.  It features:
  - support for jpeg, png, webp (decode only), tiff, and gif image formats
    (including animated gifs)
  - caching in-memory, on disk, or with Amazon S3, Google Cloud Storage, Azure
-   Storage, or Redis
+   Storage, Aliyun OSS, or Redis
  - easy deployment, since it's pure go
 
 Personally, I use it primarily to dynamically resize images hosted on my own
@@ -123,7 +123,7 @@ enabled using the `-cache` flag.  It supports the following values:
  - directory on local disk (e.g. `/tmp/imageproxy`) - will cache images
    on disk
 
- - s3 URL (e.g. `s3://region/bucket-name/optional-path-prefix`) - will cache
+ - `s3` URL (e.g. `s3://region/bucket-name/optional-path-prefix`) - will cache
    images on Amazon S3.  This requires either an IAM role and instance profile
    with access to your your bucket or `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`
    environmental variables be set. (Additional methods of loading credentials
@@ -149,13 +149,14 @@ enabled using the `-cache` flag.  It supports the following values:
 
    [aws-options]: https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config
 
- - gcs URL (e.g. `gcs://bucket-name/optional-path-prefix`) - will cache images
+ - `gcs` URL (e.g. `gcs://bucket-name/optional-path-prefix`) - will cache images
    on Google Cloud Storage. Authentication is documented in Google's
    [Application Default Credentials
    docs](https://cloud.google.com/docs/authentication/production#providing_credentials_to_your_application).
- - azure URL (e.g. `azure://container-name/`) - will cache images on
+ - `azure` URL (e.g. `azure://container-name/`) - will cache images on
    Azure Storage.  This requires `AZURESTORAGE_ACCOUNT_NAME` and
    `AZURESTORAGE_ACCESS_KEY` environment variables to bet set.
+ - `oss` URL (e.g. `oss://bucket-name/folder?endpoint=oss-cn-hangzhou.aliyuncs.com`) - will cache images on [Aliyun OSS](https://www.aliyun.com/product/oss). This requires `ALIYUN_ACCESS_KEY_ID` and `ALIYUN_ACCESS_KEY_SECRET` environment variables to bet set.
  - redis URL (e.g. `redis://hostname/`) - will cache images on
    the specified redis host. The full URL syntax is defined by the [redis URI
    registration](https://www.iana.org/assignments/uri-schemes/prov/redis).

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/peterbourgon/diskv"
 	"willnorris.com/go/imageproxy"
 	"willnorris.com/go/imageproxy/internal/gcscache"
+	"willnorris.com/go/imageproxy/internal/osscache"
 	"willnorris.com/go/imageproxy/internal/s3cache"
 )
 
@@ -165,6 +166,8 @@ func parseCache(c string) (imageproxy.Cache, error) {
 		return azurestoragecache.New("", "", u.Host)
 	case "gcs":
 		return gcscache.New(u.Host, strings.TrimPrefix(u.Path, "/"))
+	case "oss":
+		return osscache.New(u.String())
 	case "memory":
 		return lruCache(u.Opaque)
 	case "redis":

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.18 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/PaulARoy/azurestoragecache v0.0.0-20170906084534-3c249a3ba788
+	github.com/aliyun/aliyun-oss-go-sdk v2.1.7+incompatible
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/die-net/lrucache v0.0.0-20190707192454-883874fe3947
 	github.com/disintegration/imaging v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/aliyun/aliyun-oss-go-sdk v2.1.7+incompatible h1:hG4TUPxKksYy39lwrfuCYUxGtmfYwgi7OxbQInWfKMI=
+github.com/aliyun/aliyun-oss-go-sdk v2.1.7+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -657,6 +659,7 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/osscache/osscache.go
+++ b/internal/osscache/osscache.go
@@ -1,0 +1,93 @@
+// Package osscache provides an httpcache.Cache implementation that stores
+// cached values on Aliyun OSS.
+package osscache
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+)
+
+type cache struct {
+	bucket *oss.Bucket
+	prefix string
+}
+
+func (c *cache) Get(key string) ([]byte, bool) {
+	r, err := c.bucket.GetObject(c.objectKey(key))
+	if err != nil {
+		return nil, false
+	}
+	defer r.Close()
+
+	value, err := ioutil.ReadAll(r)
+	if err != nil {
+		log.Printf("error reading from aliyun oss: %v", err)
+		return nil, false
+	}
+
+	return value, true
+}
+
+func (c *cache) Set(key string, value []byte) {
+	if err := c.bucket.PutObject(c.objectKey(key), bytes.NewReader(value)); err != nil {
+		log.Printf("error writing to aliyun oss: %v", err)
+	}
+}
+
+func (c *cache) Delete(key string) {
+	if err := c.bucket.DeleteObject(c.objectKey(key)); err != nil {
+		log.Printf("error deleting aliyun oss object: %v", err)
+	}
+}
+
+func (c *cache) objectKey(key string) string {
+	return path.Join(c.prefix, keyToFilename(key))
+}
+
+func keyToFilename(key string) string {
+	h := md5.New()
+	_, _ = io.WriteString(h, key)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// New constructs a Cache storing files in the specified GCS bucket.  If prefix
+// is not empty, objects will be prefixed with that path. Credentials should
+// be specified using one of the mechanisms supported for Application Default
+// Credentials (see https://cloud.google.com/docs/authentication/production)
+func New(s string) (*cache, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := strings.TrimPrefix(u.Path, "/")
+
+	client, err := oss.New(
+		u.Query().Get("endpoint"),
+		os.Getenv("ALIYUN_ACCESS_KEY_ID"),
+		os.Getenv("ALIYUN_ACCESS_KEY_SECRET"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	bucket, err := client.Bucket(u.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cache{
+		prefix: prefix,
+		bucket: bucket,
+	}, nil
+}


### PR DESCRIPTION
[Aliyun OSS](https://aliyun.com/product/oss) or [Alibaba Cloud OSS](https://www.alibabacloud.com/product/oss) was the most popular Cloud Storage in China (like AWS S3)

This changes added for support use Aliyun OSS as cache storage.

```bash
$ ALIYUN_ACCESS_KEY_ID=xxxxx ALIYUN_ACCESS_KEY_SECRET=xxx imageproxy -cache "oss://imageproxy-test/proxy-cache?endpoint=oss-cn-hangzhou.aliyuncs.com"
```

Uploaded test result:

<img width="1436" alt="截屏2021-04-06 19 34 29" src="https://user-images.githubusercontent.com/5518/113707946-3720c780-9713-11eb-80ef-a6ddff1c5696.png">
