### PR TITLE
Add allowTransforms option for limit the transformation option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ enabled using the `-cache` flag.  It supports the following values:
 
        s3://fake-region/bucket/folder?endpoint=minio:9000&disableSSL=1&s3ForcePathStyle=1
 
-   Similarly, for [Digital Ocean Spaces](https://www.digitalocean.com/products/spaces/), 
+   Similarly, for [Digital Ocean Spaces](https://www.digitalocean.com/products/spaces/),
    provide a dummy region value and the appropriate endpoint for your space:
 
        s3://fake-region/bucket/folder?endpoint=sfo2.digitaloceanspaces.com
@@ -228,6 +228,14 @@ flag. By default, this is set to `image/*`, meaning that imageproxy will
 process any image types. You can specify multiple content types as a comma
 separated list, and suffix values with `*` to perform a wildcard match. Set the
 flag to an empty string to proxy all requests, regardless of content type.
+
+### Allowed Transformation Options ###
+
+You can limit that transformation options by using the `allowTransforms` flag.
+By default, this is empty to allows any options, meaning that imageproxy will
+process any image transformation options.
+
+    imageproxy -allowTransforms 200,600x
 
 ### Signed Requests ###
 

--- a/cmd/imageproxy-sign/main.go
+++ b/cmd/imageproxy-sign/main.go
@@ -81,7 +81,7 @@ func parseURL(s string) *url.URL {
 
 	// first try to parse this as an imageproxy URL, containing
 	// transformation options and the remote URL embedded
-	if r, err := imageproxy.NewRequest(&http.Request{URL: u}, nil); err == nil {
+	if r, err := imageproxy.NewRequest(&http.Request{URL: u}, nil, nil); err == nil {
 		r.Options.Signature = ""
 		r.URL.Fragment = r.Options.String()
 		return r.URL

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -42,6 +42,7 @@ var baseURL = flag.String("baseURL", "", "default base URL for relative remote U
 var cache tieredCache
 var signatureKeys signatureKeyList
 var scaleUp = flag.Bool("scaleUp", false, "allow images to scale beyond their original dimensions")
+var allowTransforms = flag.String("allowTransforms", "", "comma separated list of allowed transformation options, leave blank to allow all")
 var timeout = flag.Duration("timeout", 0, "time limit for requests served by this proxy")
 var verbose = flag.Bool("verbose", false, "print verbose logging messages")
 var _ = flag.Bool("version", false, "Deprecated: this flag does nothing")
@@ -69,6 +70,9 @@ func main() {
 	}
 	if *contentTypes != "" {
 		p.ContentTypes = strings.Split(*contentTypes, ",")
+	}
+	if *allowTransforms != "" {
+		p.AllowTransforms = strings.Split(*allowTransforms, ",")
 	}
 	p.SignatureKeys = signatureKeys
 	if *baseURL != "" {

--- a/imageproxy.go
+++ b/imageproxy.go
@@ -71,6 +71,9 @@ type Proxy struct {
 	// Allow images to scale beyond their original dimensions.
 	ScaleUp bool
 
+	// Allow transformation options. An empty list means no limit.
+	AllowTransforms []string
+
 	// Timeout specifies a time limit for requests served by this Proxy.
 	// If a call runs for longer than its time limit, a 504 Gateway Timeout
 	// response is returned.  A Timeout of zero means no timeout.
@@ -151,7 +154,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // serveImage handles incoming requests for proxied images.
 func (p *Proxy) serveImage(w http.ResponseWriter, r *http.Request) {
-	req, err := NewRequest(r, p.DefaultBaseURL)
+	req, err := NewRequest(r, p.DefaultBaseURL, p.AllowTransforms)
 	if err != nil {
 		msg := fmt.Sprintf("invalid request URL: %v", err)
 		p.log(msg)


### PR DESCRIPTION
Limit transformation option for avoid get attacks to resulting in waste of storage/CDN resources.

```bash
$ imageproxy -allowTransforms 200,150x300,1000x
```

```bash
$ curl http://localhost:8080/300/https://octodex.github.com/images/codercat.jpg
invalid request URL: malformed URL "/300/https://octodex.github.com/images/codercat.jpg": transformation option is not allowed

$ curl http://localhost:8080/1000x/https://octodex.github.com/images/codercat.jpg
200
```