### PR TITLE
Issue 250 encoded url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ See the full list of available options at
 ### Remote URL ###
 
 The URL of the original image to load is specified as the remainder of the
-path, without any encoding.  For example,
+path and may be URL encoded.  For example,
 `http://localhost/200/https://willnorris.com/logo.jpg`.
 
-In order to [optimize caching][], it is recommended that URLs not contain query
-strings.
+If remote image URLs contain query strings, it is recommended to URL-encode them when passing to imageproxy in order to [optimize caching][].
 
 [optimize caching]: http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/
 
@@ -75,6 +74,7 @@ x0.15   | 15% original height, proportional width  | <a href="https://imageproxy
 200x,q60 | 200px wide, proportional height, 60% quality | <a href="https://imageproxy.willnorris.com/200x,q60/https://willnorris.com/2013/12/small-things.jpg"><img src="https://imageproxy.willnorris.com/200x,q60/https://willnorris.com/2013/12/small-things.jpg" alt="200x,q60"></a>
 200x,png | 200px wide, converted to PNG format | <a href="https://imageproxy.willnorris.com/200x,png/https://willnorris.com/2013/12/small-things.jpg"><img src="https://imageproxy.willnorris.com/200x,png/https://willnorris.com/2013/12/small-things.jpg" alt="200x,png"></a>
 cx175,cw400,ch300,100x | crop to 400x300px starting at (175,0), scale to 100px wide | <a href="https://imageproxy.willnorris.com/cx175,cw400,ch300,100x/https://willnorris.com/2013/12/small-things.jpg"><img src="https://imageproxy.willnorris.com/cx175,cw400,ch300,100x/https://willnorris.com/2013/12/small-things.jpg" alt="cx175,cw400,ch300,100x"></a>
+x | no options, don't transform, just proxy | <a href="https://imageproxy.willnorris.com/x/https://willnorris.com/2013/12/small-things.jpg"><img src="https://imageproxy.willnorris.com/x/https://willnorris.com/2013/12/small-things.jpg" alt="x"></a>
 
 The [smart crop feature](https://godoc.org/willnorris.com/go/imageproxy#hdr-Smart_Crop)
 can best be seen by comparing crops of [this source image][judah-sheets], with

--- a/data_test.go
+++ b/data_test.go
@@ -247,12 +247,12 @@ func TestNewRequest_BaseURL(t *testing.T) {
 			"http://localhost/x/../foo/bar",
 			"http://example.com/foo/bar", emptyOptions, false,
 		},
-		// relative remote urls should not have URL Decoding even if
-		// they start with http... (dirname)
+		// relative remote urls (baseURL set) should not have URL Decoding even if
+		// they start with http
 		{
 			"http://example.com/hello/",
-			"http://localhost/x/httpdir/rela%20tive",
-			"http://example.com/hello/httpdir/rela%20tive", emptyOptions, false,
+			"http://localhost/x/https%3A%2F%2Fimg.example.com%2Fpic.jpg",
+			"http://example.com/hello/https%3A%2F%2Fimg.example.com%2Fpic.jpg", emptyOptions, false,
 		},
 	}
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -444,7 +444,7 @@ func TestProxy_ServeHTTP_maxRedirects(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		req, _ := http.NewRequest("GET", "http://localhost"+tt.url, nil)
+		req, _ := http.NewRequest("GET", "http://localhost/x"+tt.url, nil)
 		resp := httptest.NewRecorder()
 		p.ServeHTTP(resp, req)
 

--- a/imageproxy_test.go
+++ b/imageproxy_test.go
@@ -382,10 +382,10 @@ func TestProxy_ServeHTTP(t *testing.T) {
 		code int    // expected response status code
 	}{
 		{"/favicon.ico", http.StatusOK},
-		{"//foo", http.StatusBadRequest},                            // invalid request URL
-		{"/http://bad.test/", http.StatusForbidden},                 // Disallowed host
-		{"/http://good.test/error", http.StatusInternalServerError}, // HTTP protocol error
-		{"/http://good.test/nocontent", http.StatusNoContent},       // non-OK response
+		{"/x/foo", http.StatusBadRequest},                             // invalid request URL
+		{"/x/http://bad.test/", http.StatusForbidden},                 // Disallowed host
+		{"/x/http://good.test/error", http.StatusInternalServerError}, // HTTP protocol error
+		{"/x/http://good.test/nocontent", http.StatusNoContent},       // non-OK response
 		{"/100/http://good.test/png", http.StatusOK},
 		{"/100/http://good.test/plain", http.StatusForbidden}, // non-image response
 
@@ -413,7 +413,7 @@ func TestProxy_ServeHTTP_is304(t *testing.T) {
 		},
 	}
 
-	req, _ := http.NewRequest("GET", "http://localhost/http://good.test/etag", nil)
+	req, _ := http.NewRequest("GET", "http://localhost/x/http://good.test/etag", nil)
 	req.Header.Add("If-None-Match", `"tag"`)
 	resp := httptest.NewRecorder()
 	p.ServeHTTP(resp, req)


### PR DESCRIPTION
# Supporting url-encoded remote URLs as parameter

You can find more monologue about motivation (real world cases) and the implementation approach for this change in #250.

## Summary

- Options parameter is no longer optional.  You can pass `//http...` or `/x/http...` or `/0x0/http...`  but **not** `/http...`.
- URL encoding of remote urls is now supported (but still optional).
- Added more test cases.

**Before** this change, the code would attempt to URL-parse the first param and if that failed then assumed there were options present.  That meant in the common case (options and url present) both the options and url would be attempted to be URL parsed in the logic.  Now we expect parseable options to always be the first parameter.

The fact that options **were** optional (before this change) was not documented in the README, only in the code...so hoping this isn't a breaking change for most users.  The fix is to add an empty/no-op option before the remote URL parameter (`//http...` or `/x/http...` or `/0x0/http...`).