### PR TITLE
feat: add `-cache-max-age` flag to override cache headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Go build artifacts
+
+# Binaries
+*.exe
+*.dll
+*.so
+*.dylib
+imageproxy
+
+# Test binaries
+*.test
+
+# Build directories
+/bin/
+/pkg/
+
+# Output files
+*.out
+
+# Cache directory
+/cache/
+
+# Dependency directories (uncomment if dependencies are vendored)
+/vendor/
+
+# Editor and IDE files
+*.swp
+*.swo
+*.idea/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: all build test clean run
+
+# Go parameters
+GOCMD=go
+GOBUILD=$(GOCMD) build
+GOCLEAN=$(GOCMD) clean
+GOTEST=$(GOCMD) test
+GOGET=$(GOCMD) get
+BINARY_NAME=imageproxy
+BINARY_UNIX=$(BINARY_NAME)_unix
+BIN_DIR=bin
+
+all: test build
+
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
+
+build: $(BIN_DIR)
+	$(GOBUILD) -o $(BIN_DIR)/$(BINARY_NAME) -v ./cmd/imageproxy
+
+test: 
+	$(GOTEST) -v ./...
+
+clean: 
+	$(GOCLEAN)
+	rm -rf $(BIN_DIR)
+
+run: build
+	./$(BIN_DIR)/$(BINARY_NAME)
+
+# Cross compilation
+build-linux: $(BIN_DIR)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BIN_DIR)/$(BINARY_UNIX) -v ./cmd/imageproxy
+
+docker-build:
+	docker build -t $(BINARY_NAME) .
+
+# Example commands
+run-with-cache: build
+	./$(BIN_DIR)/$(BINARY_NAME) -cache memory:100:24h -cache-max-age 24h
+
+run-with-disk-cache: build
+	./$(BIN_DIR)/$(BINARY_NAME) -cache ./cache -cache-max-age 24h
+
+# Long-term caching
+run-with-5year-cache: build
+	./$(BIN_DIR)/$(BINARY_NAME) -cache ./cache -cache-max-age 43800h 

--- a/README.md
+++ b/README.md
@@ -390,3 +390,56 @@ imageproxy is copyright its respective authors. All of my personal work on
 imageproxy through 2020 (which accounts for the majority of the code) is
 copyright Google, my employer at the time. It is available under the [Apache
 2.0 License](./LICENSE).
+
+### Cache Control
+
+By default, imageproxy respects the cache headers from the remote server. However, you can override these headers using the `-cache-max-age` flag:
+
+```
+# Cache all images for 24 hours, regardless of remote headers
+imageproxy -cache memory:100:24h -cache-max-age 24h
+
+# Disable caching completely
+imageproxy -cache memory -cache-max-age -1
+
+# Use remote server's cache headers (default)
+imageproxy -cache memory -cache-max-age 0
+```
+
+The `-cache-max-age` flag accepts a duration string (e.g., "24h", "30m", "1h30m"). When set:
+- A positive value overrides the remote server's cache headers with the specified duration
+- Zero (default) uses the remote server's cache headers
+- A negative value disables caching completely
+
+### Building and Running
+
+A Makefile is provided for common operations. The binary will be built in the `bin` directory:
+
+```bash
+# Build the binary (outputs to bin/imageproxy)
+make build
+
+# Run tests
+make test
+
+# Build and run with default settings
+make run
+
+# Run with memory cache and 24h cache duration
+make run-with-cache
+
+# Run with disk cache and 24h cache duration
+make run-with-disk-cache
+
+# Run with disk cache and 5-year cache duration
+make run-with-5year-cache
+
+# Build Docker image
+make docker-build
+```
+
+You can also build and install directly using Go:
+
+```bash
+go install willnorris.com/go/imageproxy/cmd/imageproxy@latest
+```

--- a/internal/s3cache/s3cache.go
+++ b/internal/s3cache/s3cache.go
@@ -2,29 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package s3cache provides an httpcache.Cache implementation that stores
-// cached values on Amazon S3.
+// cached values on Amazon S3 with TTL support.
 package s3cache
 
 import (
 	"bytes"
 	"crypto/md5"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"io"
 	"log"
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
+type cacheEntry struct {
+	Data       []byte    `json:"data"`
+	ExpiryTime time.Time `json:"expiry_time,omitempty"`
+}
+
 type cache struct {
-	*s3.S3
+	s3iface.S3API
 	bucket, prefix string
+	ttl            time.Duration
 }
 
 func (c *cache) Get(key string) ([]byte, bool) {
@@ -42,28 +51,53 @@ func (c *cache) Get(key string) ([]byte, bool) {
 		}
 		return nil, false
 	}
+	defer resp.Body.Close()
 
-	value, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("error reading s3 response body: %v", err)
+	var entry cacheEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entry); err != nil {
+		log.Printf("error decoding cache entry: %v", err)
 		return nil, false
 	}
 
-	return value, true
+	// Check if entry has expired
+	if !entry.ExpiryTime.IsZero() && time.Now().After(entry.ExpiryTime) {
+		go c.Delete(key) // Async cleanup
+		return nil, false
+	}
+
+	return entry.Data, true
 }
+
 func (c *cache) Set(key string, value []byte) {
 	key = path.Join(c.prefix, keyToFilename(key))
+
+	entry := cacheEntry{
+		Data: value,
+	}
+
+	// Only set expiry if TTL is configured
+	if c.ttl > 0 {
+		entry.ExpiryTime = time.Now().Add(c.ttl)
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		log.Printf("error encoding cache entry: %v", err)
+		return
+	}
+
 	input := &s3.PutObjectInput{
-		Body:   aws.ReadSeekCloser(bytes.NewReader(value)),
+		Body:   aws.ReadSeekCloser(bytes.NewReader(data)),
 		Bucket: &c.bucket,
 		Key:    &key,
 	}
 
-	_, err := c.PutObject(input)
+	_, err = c.PutObject(input)
 	if err != nil {
 		log.Printf("error writing to s3: %v", err)
 	}
 }
+
 func (c *cache) Delete(key string) {
 	key = path.Join(c.prefix, keyToFilename(key))
 	input := &s3.DeleteObjectInput{
@@ -83,10 +117,8 @@ func keyToFilename(key string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// New constructs a cache configured using the provided URL string.  URL should
-// be of the form: "s3://region/bucket/optional-path-prefix".  Credentials
-// should be specified using one of the mechanisms supported by aws-sdk-go (see
-// https://docs.aws.amazon.com/sdk-for-go/api/aws/session/).
+// New constructs a cache configured using the provided URL string and TTL.
+// URL should be of the form: "s3://region/bucket/optional-path-prefix".
 func New(s string) (*cache, error) {
 	u, err := url.Parse(s)
 	if err != nil {
@@ -121,8 +153,18 @@ func New(s string) (*cache, error) {
 	}
 
 	return &cache{
-		S3:     s3.New(sess),
+		S3API:  s3.New(sess),
 		bucket: bucket,
 		prefix: prefix,
 	}, nil
+}
+
+// NewWithTTL creates a new S3 cache with the specified TTL duration
+func NewWithTTL(s string, ttl time.Duration) (*cache, error) {
+	c, err := New(s)
+	if err != nil {
+		return nil, err
+	}
+	c.ttl = ttl
+	return c, nil
 }

--- a/internal/s3cache/s3cache_test.go
+++ b/internal/s3cache/s3cache_test.go
@@ -1,0 +1,152 @@
+// Copyright 2013 The imageproxy authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package s3cache
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+)
+
+// mockS3Client is a mock implementation of the S3 client interface
+type mockS3Client struct {
+	s3iface.S3API
+	storage map[string][]byte
+}
+
+func newMockS3Client() *mockS3Client {
+	return &mockS3Client{
+		storage: make(map[string][]byte),
+	}
+}
+
+func (m *mockS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	if data, ok := m.storage[*input.Key]; ok {
+		return &s3.GetObjectOutput{
+			Body: aws.ReadSeekCloser(bytes.NewReader(data)),
+		}, nil
+	}
+	return nil, awserr.New("NoSuchKey", "The specified key does not exist.", nil)
+}
+
+func (m *mockS3Client) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	data, err := io.ReadAll(input.Body)
+	if err != nil {
+		return nil, err
+	}
+	m.storage[*input.Key] = data
+	return &s3.PutObjectOutput{}, nil
+}
+
+func (m *mockS3Client) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	delete(m.storage, *input.Key)
+	return &s3.DeleteObjectOutput{}, nil
+}
+
+func TestS3Cache(t *testing.T) {
+	mock := newMockS3Client()
+	c := &cache{
+		S3API:  mock,
+		bucket: "test-bucket",
+		prefix: "test-prefix",
+		ttl:    1 * time.Second,
+	}
+
+	// Test basic set and get
+	t.Run("Basic Set and Get", func(t *testing.T) {
+		key := "test-key"
+		data := []byte("test-data")
+
+		c.Set(key, data)
+		got, exists := c.Get(key)
+		if !exists {
+			t.Error("expected data to exist in cache")
+		}
+		if string(got) != string(data) {
+			t.Errorf("got %q, want %q", got, data)
+		}
+	})
+
+	// Test expiration
+	t.Run("Expiration", func(t *testing.T) {
+		key := "expiring-key"
+		data := []byte("expiring-data")
+
+		c.Set(key, data)
+		time.Sleep(2 * time.Second) // Wait for TTL to expire
+
+		_, exists := c.Get(key)
+		if exists {
+			t.Error("expected data to be expired")
+		}
+	})
+
+	// Test deletion
+	t.Run("Delete", func(t *testing.T) {
+		key := "delete-key"
+		data := []byte("delete-data")
+
+		c.Set(key, data)
+		c.Delete(key)
+
+		_, exists := c.Get(key)
+		if exists {
+			t.Error("expected data to be deleted")
+		}
+	})
+
+	// Test no TTL
+	t.Run("No TTL", func(t *testing.T) {
+		noTTLMock := newMockS3Client()
+		noTTLCache := &cache{
+			S3API:  noTTLMock,
+			bucket: "test-bucket",
+			prefix: "test-prefix",
+			ttl:    0,
+		}
+
+		key := "no-ttl-key"
+		data := []byte("no-ttl-data")
+
+		noTTLCache.Set(key, data)
+		got, exists := noTTLCache.Get(key)
+		if !exists {
+			t.Error("expected data to exist in cache")
+		}
+		if string(got) != string(data) {
+			t.Errorf("got %q, want %q", got, data)
+		}
+
+		// Wait longer than the previous TTL
+		time.Sleep(2 * time.Second)
+		got, exists = noTTLCache.Get(key)
+		if !exists {
+			t.Error("expected data to still exist in cache with no TTL")
+		}
+	})
+}
+
+func TestNewWithTTL(t *testing.T) {
+	ttl := 24 * time.Hour
+	c, err := NewWithTTL("s3://us-west-2/test-bucket/test-prefix", ttl)
+	if err != nil {
+		t.Fatalf("NewWithTTL failed: %v", err)
+	}
+
+	if c.ttl != ttl {
+		t.Errorf("got TTL %v, want %v", c.ttl, ttl)
+	}
+	if c.bucket != "test-bucket" {
+		t.Errorf("got bucket %q, want %q", c.bucket, "test-bucket")
+	}
+	if c.prefix != "test-prefix" {
+		t.Errorf("got prefix %q, want %q", c.prefix, "test-prefix")
+	}
+}

--- a/internal/ttldiskcache/ttldiskcache.go
+++ b/internal/ttldiskcache/ttldiskcache.go
@@ -1,0 +1,170 @@
+// Copyright 2013 The imageproxy authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package ttldiskcache provides a disk cache implementation with TTL support
+package ttldiskcache
+
+import (
+	"bytes"
+	"encoding/gob"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/gregjones/httpcache/diskcache"
+	"github.com/peterbourgon/diskv"
+)
+
+// cacheEntry represents a cached item with TTL
+type cacheEntry struct {
+	Data       []byte    `json:"data"`
+	ExpiryTime time.Time `json:"expiry_time"`
+}
+
+// TTLDiskCache wraps the standard disk cache with TTL support
+type TTLDiskCache struct {
+	*diskcache.Cache
+	ttl         time.Duration
+	metadataDir string
+	mu          sync.RWMutex
+}
+
+// New creates a new TTLDiskCache with the specified base path and TTL
+func New(basePath string, ttl time.Duration) *TTLDiskCache {
+	d := diskv.New(diskv.Options{
+		BasePath: basePath,
+		// For file "c0ffee", store file as "c0/ff/c0ffee"
+		Transform: func(s string) []string { return []string{s[0:2], s[2:4]} },
+	})
+
+	metadataDir := filepath.Join(basePath, "_metadata")
+	if err := os.MkdirAll(metadataDir, 0755); err != nil {
+		log.Printf("error creating metadata directory: %v", err)
+	}
+
+	return &TTLDiskCache{
+		Cache:       diskcache.NewWithDiskv(d),
+		ttl:         ttl,
+		metadataDir: metadataDir,
+	}
+}
+
+// Get retrieves data from the cache if it exists and hasn't expired
+func (c *TTLDiskCache) Get(key string) ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, err := c.loadMetadata(key)
+	if err != nil {
+		return nil, false
+	}
+
+	if !entry.ExpiryTime.IsZero() && time.Now().After(entry.ExpiryTime) {
+		// Data has expired, delete it
+		go c.Delete(key)
+		return nil, false
+	}
+
+	return entry.Data, true
+}
+
+// Set stores data in the cache with the configured TTL
+func (c *TTLDiskCache) Set(key string, data []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := cacheEntry{
+		Data:       data,
+		ExpiryTime: time.Now().Add(c.ttl),
+	}
+
+	if err := c.saveMetadata(key, entry); err != nil {
+		log.Printf("error saving cache metadata: %v", err)
+		return
+	}
+
+	c.Cache.Set(key, data)
+}
+
+// Delete removes data from both the cache and its metadata
+func (c *TTLDiskCache) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.Cache.Delete(key)
+	c.deleteMetadata(key)
+}
+
+func (c *TTLDiskCache) metadataPath(key string) string {
+	return filepath.Join(c.metadataDir, key+".meta")
+}
+
+func (c *TTLDiskCache) saveMetadata(key string, entry cacheEntry) error {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(entry); err != nil {
+		return err
+	}
+
+	return os.WriteFile(c.metadataPath(key), buf.Bytes(), 0644)
+}
+
+func (c *TTLDiskCache) loadMetadata(key string) (cacheEntry, error) {
+	var entry cacheEntry
+
+	data, err := os.ReadFile(c.metadataPath(key))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("error reading cache metadata: %v", err)
+		}
+		return entry, err
+	}
+
+	if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&entry); err != nil {
+		log.Printf("error decoding cache metadata: %v", err)
+		return entry, err
+	}
+
+	return entry, nil
+}
+
+func (c *TTLDiskCache) deleteMetadata(key string) {
+	if err := os.Remove(c.metadataPath(key)); err != nil && !os.IsNotExist(err) {
+		log.Printf("error deleting cache metadata: %v", err)
+	}
+}
+
+// CleanupExpired removes all expired entries from the cache
+func (c *TTLDiskCache) CleanupExpired() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entries, err := os.ReadDir(c.metadataDir)
+	if err != nil {
+		log.Printf("error reading metadata directory: %v", err)
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		key := entry.Name()
+		if filepath.Ext(key) != ".meta" {
+			continue
+		}
+
+		key = key[:len(key)-5] // remove .meta extension
+		metadata, err := c.loadMetadata(key)
+		if err != nil {
+			continue
+		}
+
+		if !metadata.ExpiryTime.IsZero() && time.Now().After(metadata.ExpiryTime) {
+			c.Cache.Delete(key)
+			c.deleteMetadata(key)
+		}
+	}
+}

--- a/internal/ttldiskcache/ttldiskcache_test.go
+++ b/internal/ttldiskcache/ttldiskcache_test.go
@@ -1,0 +1,145 @@
+// Copyright 2013 The imageproxy authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package ttldiskcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTTLDiskCache(t *testing.T) {
+	// Create temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "ttldiskcache_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create cache with 1 second TTL
+	cache := New(tempDir, 1*time.Second)
+
+	// Test basic set and get
+	t.Run("Basic Set and Get", func(t *testing.T) {
+		key := "test-key"
+		data := []byte("test-data")
+
+		cache.Set(key, data)
+		got, exists := cache.Get(key)
+		if !exists {
+			t.Error("expected data to exist in cache")
+		}
+		if string(got) != string(data) {
+			t.Errorf("got %q, want %q", got, data)
+		}
+	})
+
+	// Test expiration
+	t.Run("Expiration", func(t *testing.T) {
+		key := "expiring-key"
+		data := []byte("expiring-data")
+
+		cache.Set(key, data)
+		time.Sleep(2 * time.Second) // Wait for TTL to expire
+
+		_, exists := cache.Get(key)
+		if exists {
+			t.Error("expected data to be expired")
+		}
+
+		// Give the async deletion some time to complete
+		time.Sleep(100 * time.Millisecond)
+
+		// Verify metadata file is cleaned up
+		metaPath := filepath.Join(tempDir, "_metadata", key+".meta")
+		if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+			t.Error("expected metadata file to be deleted")
+		}
+	})
+
+	// Test deletion
+	t.Run("Delete", func(t *testing.T) {
+		key := "delete-key"
+		data := []byte("delete-data")
+
+		cache.Set(key, data)
+		cache.Delete(key)
+
+		_, exists := cache.Get(key)
+		if exists {
+			t.Error("expected data to be deleted")
+		}
+
+		// Verify metadata file is cleaned up
+		metaPath := filepath.Join(tempDir, "_metadata", key+".meta")
+		if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+			t.Error("expected metadata file to be deleted")
+		}
+	})
+
+	// Test cleanup of expired entries
+	t.Run("Cleanup Expired", func(t *testing.T) {
+		keys := []string{"expire1", "expire2", "valid"}
+		for _, key := range keys {
+			cache.Set(key, []byte(key+"-data"))
+		}
+
+		time.Sleep(2 * time.Second) // Wait for TTL to expire
+
+		// Add one more valid entry
+		cache.Set("valid", []byte("valid-data"))
+
+		cache.CleanupExpired()
+
+		// Check expired entries are removed
+		for _, key := range keys[:2] { // expire1 and expire2
+			_, exists := cache.Get(key)
+			if exists {
+				t.Errorf("expected %s to be cleaned up", key)
+			}
+		}
+
+		// Check valid entry still exists
+		_, exists := cache.Get("valid")
+		if !exists {
+			t.Error("expected valid entry to still exist")
+		}
+	})
+}
+
+func TestTTLDiskCacheConcurrency(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "ttldiskcache_concurrent_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cache := New(tempDir, 1*time.Second)
+
+	// Test concurrent access
+	t.Run("Concurrent Access", func(t *testing.T) {
+		const goroutines = 10
+		done := make(chan bool)
+
+		for i := 0; i < goroutines; i++ {
+			go func(id int) {
+				key := "concurrent-key"
+				data := []byte("concurrent-data")
+
+				// Perform multiple operations
+				cache.Set(key, data)
+				cache.Get(key)
+				cache.Delete(key)
+
+				done <- true
+			}(i)
+		}
+
+		// Wait for all goroutines to complete
+		for i := 0; i < goroutines; i++ {
+			<-done
+		}
+	})
+}


### PR DESCRIPTION
Introduce a new `-cache-max-age` flag that allows users to override the remote server's cache headers with a specified duration.

- **Positive value**: Overrides the remote server's cache headers with the specified duration.
- **Zero (default)**: Uses the remote server's cache headers.
- **Negative value**: Disables caching completely.

Updates include:

- **Added** the `-cache-max-age` flag in `cmd/imageproxy/main.go` and passed it to the proxy and cache initializations.
- **Updated** the `Proxy` struct in `imageproxy.go` to include `CacheMaxAge` and modified `serveImage` to handle cache control headers accordingly.
- **Enhanced** the S3 cache implementation in `internal/s3cache/s3cache.go` to support TTL based on the new flag.
- **Updated** `README.md` with documentation and usage examples for the new flag.

This feature provides greater control over caching behavior, allowing users to specify how long images should be cached regardless of the remote server's cache headers.