### PR TITLE
transform: change default encoding for webp and tiff to png to preserve transparency

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -58,9 +58,9 @@ func Transform(img []byte, opt Options) ([]byte, error) {
 		}
 	}
 
-	// encode webp and tiff as jpeg by default
+	// encode webp and tiff as png by default to preserve transparency
 	if format == "tiff" || format == "webp" {
-		format = "jpeg"
+		format = "png"
 	}
 
 	if opt.Format != "" {


### PR DESCRIPTION
We noticed that converting webp images to jpeg did not preserve transparency (or the alpha channel), and this simple change will make webp images with transparent backgrounds also preserve this after transformation instead of getting a black background.

Before: 
![WEB_Image_07-520449_1405008191_plid_7](https://github.com/user-attachments/assets/4c39c26f-3d64-4d3a-aaed-d99fbfb31fbc)

After:
![WEB_Image_07-520449_1405008191_plid_7](https://github.com/user-attachments/assets/7287b80c-d673-4f16-bb3e-028b4d21c3d0)

