### PR TITLE
allow overriding cache directives in responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.cache
+imageproxy

--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ first check an in-memory cache for an image, followed by a gcs bucket:
 
 [tiered fashion]: https://godoc.org/github.com/die-net/lrucache/twotier
 
+#### Cache Duration
+
+By default, images are cached for the duration specified in response headers.
+If an image has no cache directives, or an explicit `Cache-Control: no-cache` header,
+then the response is not cached.
+
+To override the response cache directives, set a minimum time that response should be cached for.
+This will ignore `no-cache` and `no-store` directives, and will set `max-age`
+to the specified value if it is greater than the original `max-age` value.
+
+    imageproxy -cache /tmp/imageproxy -minCacheDuration 5m
+
 ### Allowed Referrer List
 
 You can limit images to only be accessible for certain hosts in the HTTP

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -46,6 +46,7 @@ var verbose = flag.Bool("verbose", false, "print verbose logging messages")
 var _ = flag.Bool("version", false, "Deprecated: this flag does nothing")
 var contentTypes = flag.String("contentTypes", "image/*", "comma separated list of allowed content types")
 var userAgent = flag.String("userAgent", "willnorris/imageproxy", "specify the user-agent used by imageproxy when fetching images from origin website")
+var minCacheDuration = flag.Duration("minCacheDuration", 0, "minimum duration to cache remote images")
 
 func init() {
 	flag.Var(&cache, "cache", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")
@@ -87,6 +88,7 @@ func main() {
 	p.ScaleUp = *scaleUp
 	p.Verbose = *verbose
 	p.UserAgent = *userAgent
+	p.MinimumCacheDuration = *minCacheDuration
 
 	server := &http.Server{
 		Addr:    *addr,

--- a/third_party/httpcache/LICENSE
+++ b/third_party/httpcache/LICENSE
@@ -1,0 +1,7 @@
+Copyright © 2012 Greg Jones (greg.jones@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third_party/httpcache/README.md
+++ b/third_party/httpcache/README.md
@@ -1,0 +1,2 @@
+httpcache is a copy of <https://github.com/gregjones/httpcache>
+with only the cache control header parsing logic.

--- a/third_party/httpcache/httpcache.go
+++ b/third_party/httpcache/httpcache.go
@@ -1,0 +1,26 @@
+package httpcache
+
+import (
+	"net/http"
+	"strings"
+)
+
+type cacheControl map[string]string
+
+func parseCacheControl(headers http.Header) cacheControl {
+	cc := cacheControl{}
+	ccHeader := headers.Get("Cache-Control")
+	for _, part := range strings.Split(ccHeader, ",") {
+		part = strings.Trim(part, " ")
+		if part == "" {
+			continue
+		}
+		if strings.ContainsRune(part, '=') {
+			keyval := strings.Split(part, "=")
+			cc[strings.Trim(keyval[0], " ")] = strings.Trim(keyval[1], ",")
+		} else {
+			cc[part] = ""
+		}
+	}
+	return cc
+}

--- a/third_party/httpcache/httpcache.go
+++ b/third_party/httpcache/httpcache.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 )
 
-type cacheControl map[string]string
+type CacheControl map[string]string
 
-func parseCacheControl(headers http.Header) cacheControl {
-	cc := cacheControl{}
+func ParseCacheControl(headers http.Header) CacheControl {
+	cc := CacheControl{}
 	ccHeader := headers.Get("Cache-Control")
 	for _, part := range strings.Split(ccHeader, ",") {
 		part = strings.Trim(part, " ")
@@ -23,4 +23,16 @@ func parseCacheControl(headers http.Header) cacheControl {
 		}
 	}
 	return cc
+}
+
+func (cc CacheControl) String() string {
+	parts := make([]string, 0, len(cc))
+	for k, v := range cc {
+		if v == "" {
+			parts = append(parts, k)
+		} else {
+			parts = append(parts, k+"="+v)
+		}
+	}
+	return strings.Join(parts, ", ")
 }


### PR DESCRIPTION
Add a new `-minCacheDuration` flag to specify a minimum duration to cache images for.

Updates https://github.com/willnorris/imageproxy/issues/28
Updates https://github.com/willnorris/imageproxy/issues/144
Fixes https://github.com/willnorris/imageproxy/issues/207
Fixes https://github.com/willnorris/imageproxy/pull/208