### PR TITLE
add -forceCache flag to override no-store and private directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,15 +184,19 @@ first check an in-memory cache for an image, followed by a gcs bucket:
 
 [tiered fashion]: https://pkg.go.dev/github.com/die-net/lrucache/twotier
 
-#### Cache Duration
+#### Override Cache Directives
 
-By default, images are cached for the duration specified in response headers.
-If an image has no cache directives, or an explicit `Cache-Control: no-cache` header,
-then the response is not cached.
+By default, imageproxy will respect the caching directives in response headers,
+including the cache duration and explicit instructions **not** to cache the response,
+such as `no-store` and `private` cache-control directives.
 
-To override the response cache directives, set a minimum time that response should be cached for.
-This will ignore `no-cache` and `no-store` directives, and will set `max-age`
-to the specified value if it is greater than the original `max-age` value.
+You can force imageproxy to cache responses, even if they explicitly say not to,
+by passing the `-forceCache` flag. Note that this is generally not recommended.
+
+A minimum cache duration can be set using the `-minCacheDuration` flag. This
+will extend the cache duration if the response header indicates a shorter value.
+If called without the `-forceCache` flag, this will have no effect on responses
+with the `no-store` or `private` directives.
 
     imageproxy -cache /tmp/imageproxy -minCacheDuration 5m
 

--- a/cmd/imageproxy/main.go
+++ b/cmd/imageproxy/main.go
@@ -47,6 +47,7 @@ var _ = flag.Bool("version", false, "Deprecated: this flag does nothing")
 var contentTypes = flag.String("contentTypes", "image/*", "comma separated list of allowed content types")
 var userAgent = flag.String("userAgent", "willnorris/imageproxy", "specify the user-agent used by imageproxy when fetching images from origin website")
 var minCacheDuration = flag.Duration("minCacheDuration", 0, "minimum duration to cache remote images")
+var forceCache = flag.Bool("forceCache", false, "Ignore no-store and private directives in responses")
 
 func init() {
 	flag.Var(&cache, "cache", "location to cache images (see https://github.com/willnorris/imageproxy#cache)")
@@ -89,6 +90,7 @@ func main() {
 	p.Verbose = *verbose
 	p.UserAgent = *userAgent
 	p.MinimumCacheDuration = *minCacheDuration
+	p.ForceCache = *forceCache
 
 	server := &http.Server{
 		Addr:    *addr,

--- a/third_party/httpcache/httpcache.go
+++ b/third_party/httpcache/httpcache.go
@@ -2,6 +2,7 @@ package httpcache
 
 import (
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -17,9 +18,9 @@ func ParseCacheControl(headers http.Header) CacheControl {
 		}
 		if strings.ContainsRune(part, '=') {
 			keyval := strings.Split(part, "=")
-			cc[strings.Trim(keyval[0], " ")] = strings.Trim(keyval[1], ",")
+			cc[strings.ToLower(strings.Trim(keyval[0], " "))] = strings.Trim(keyval[1], ",")
 		} else {
-			cc[part] = ""
+			cc[strings.ToLower(part)] = ""
 		}
 	}
 	return cc
@@ -34,5 +35,6 @@ func (cc CacheControl) String() string {
 			parts = append(parts, k+"="+v)
 		}
 	}
+	sort.StringSlice(parts).Sort()
 	return strings.Join(parts, ", ")
 }


### PR DESCRIPTION
The httpcache package is intended only to be used in private caches, so it will cache responses marked `private` like normal.  However, imageproxy is a shared cache, so these response should not be cached under normal circumstances.  This change introduces a potentially breaking change to start respecting the `private` cache directive in responses.

This also adds a new `-forceCache` flag to ignore the `private` and `no-store` directives, and cache all responses regardless.