### PR TITLE
fix: return a more-complete 304 from TransformingTransport.RoundTrip

### DIFF
--- a/imageproxy.go
+++ b/imageproxy.go
@@ -573,7 +573,14 @@ func (t *TransformingTransport) RoundTrip(req *http.Request) (*http.Response, er
 
 	if should304(req, resp) {
 		// bare 304 response, full response will be used from cache
-		return &http.Response{StatusCode: http.StatusNotModified}, nil
+		return &http.Response{
+			Proto:      "HTTP/1.1",
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Status:     fmt.Sprintf("%d %s", http.StatusNotModified, http.StatusText(http.StatusNotModified)),
+			StatusCode: http.StatusNotModified,
+			Body:       http.NoBody,
+		}, nil
 	}
 
 	b, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
Return a more-complete 304 from TransformingTransport.RoundTrip to address a segfault we're seeing in production. The necessary conditions for the issue are:

1. A remote service returning a 303 response which must contain a location URI that changes every time, so that the real location of the image is never cached. As an example, if the remove service redirects to S3, the presence of the `X-Amz-Security-Token` accomplishes this.

2. The image responses must match by Etag, so that imageProxy.should304() returns true causing TranformingTransport.RoundTrip() to return a bare 304 response.

If those conditions are met, then the bare 304 Response returned will be used and read by one of the callers. Specifically, the lack of a Body causes a segfault.

So let's make it more like a real Response and use http.NoBody so when it's used it doesn't cause things to explode.

---

This issue involves a complex set of interactions between objects, which I tried to illustrate in a flow diagram here.

![image](https://github.com/user-attachments/assets/d894b2a4-db4f-4fb2-956b-ea8a03ddbd29)

This diagram may not actually be helpful to readers, and for that I'm sorry -- but constructing it was very helpful to me to understand the preconditions and the fix (which is relatively simple).