### PR TITLE
add "valid until" option to limit lifetime of signed requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,14 @@ If both a whiltelist and signatureKey are specified, requests can match either.
 In other words, requests that match one of the allowed hosts don't necessarily
 need to be signed, though they can be.
 
+To limit how long a URL is valid (particularly useful for signed URLs),
+you can specify a "valid until" time using the `vu` option with a Unix timestamp.
+For example, the following signed URL would only be valid until 2020-01-01:
+
+```
+http://localhost:8080/vu1577836800,sjNcVf6LxzKEvR6Owgg3zhEMN7xbWxlpf-eyYbRfFK4A=/https://example.com/image
+```
+
 ### Default Base URL
 
 Typically, remote images to be proxied are specified as absolute URLs.

--- a/data_test.go
+++ b/data_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 )
 
 var emptyOptions = Options{}
@@ -25,8 +26,8 @@ func TestOptions_String(t *testing.T) {
 			"1x2,fh,fit,fv,q80,r90",
 		},
 		{
-			Options{Width: 0.15, Height: 1.3, Rotate: 45, Quality: 95, Signature: "c0ffee", Format: "png"},
-			"0.15x1.3,png,q95,r45,sc0ffee",
+			Options{Width: 0.15, Height: 1.3, Rotate: 45, Quality: 95, Signature: "c0ffee", Format: "png", ValidUntil: time.Unix(123, 0)},
+			"0.15x1.3,png,q95,r45,sc0ffee,vu123",
 		},
 		{
 			Options{Width: 0.15, Height: 1.3, CropX: 100, CropY: 200},
@@ -86,7 +87,7 @@ func TestParseOptions(t *testing.T) {
 		// flags, in different orders
 		{"q70,1x2,fit,r90,fv,fh,sc0ffee,png", Options{Width: 1, Height: 2, Fit: true, Rotate: 90, FlipVertical: true, FlipHorizontal: true, Quality: 70, Signature: "c0ffee", Format: "png"}},
 		{"r90,fh,sc0ffee,png,q90,1x2,fv,fit", Options{Width: 1, Height: 2, Fit: true, Rotate: 90, FlipVertical: true, FlipHorizontal: true, Quality: 90, Signature: "c0ffee", Format: "png"}},
-		{"cx100,cw300,1x2,cy200,ch400,sc,scaleUp", Options{Width: 1, Height: 2, ScaleUp: true, CropX: 100, CropY: 200, CropWidth: 300, CropHeight: 400, SmartCrop: true}},
+		{"cx100,cw300,1x2,cy200,ch400,sc,scaleUp,vu1234567890", Options{Width: 1, Height: 2, ScaleUp: true, CropX: 100, CropY: 200, CropWidth: 300, CropHeight: 400, SmartCrop: true, ValidUntil: time.Unix(1234567890, 0)}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This is a modification of the commit from #222.  Instead of using `YYYYMMDD` format external, use Unix timestamps.  Internally, convert that to a `time.Time` so that we can use standard methods to compare values.

Closes #222