### PR TITLE
chore(docker): strip debug information to shrink image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v ./cmd/imageproxy
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags='-w -s' -v ./cmd/imageproxy
 
 FROM cgr.dev/chainguard/static:latest
 


### PR DESCRIPTION
This PR adds `-ldflags='-w -s'` to the Dockerfile, which instructs the linker to strip debug information, resulting in a smaller binary size. On my machine, this shrinks the image by 17.4 MB, but each `GOOS` and `GOARCH` will differ slightly.