### PR TITLE
.github: fix go-version for test-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,10 +53,6 @@ jobs:
   test-latest:
     strategy:
       fail-fast: false
-      matrix:
-        go:
-          - { go-version: stable }
-          - { go-version-file: go.mod }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -64,8 +60,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go.go-version }}
-          go-version-file: ${{ matrix.go.go-version-file }}
+          go-version: stable
       - uses: geomys/sandboxed-step@7d75eb49d17fdeeb3656b3a57d35932d205bcfb9 # v1.2.1
         with:
           run: |


### PR DESCRIPTION
We don't need the version matrix here, and don't want to reference the go version in go.mod.  Instead, just always use stable.